### PR TITLE
EPROD 866 remove utxos from ledger after they are used

### DIFF
--- a/scripts/rune_deploy.sh
+++ b/scripts/rune_deploy.sh
@@ -18,6 +18,11 @@
 
 set -e
 
+if [ -z "$(which ord)" ]; then
+  echo "ord is missing; please install ord with: curl --proto '=https' --tlsv1.2 -fsLS https://ordinals.com/install.sh | bash -s"
+  exit 1
+fi
+
 CHAIN_ID=355113
 
 ORD_DATA=$PWD/target/ord
@@ -26,6 +31,11 @@ RUNE_ID=$(ord -r --data-dir $ORD_DATA --index-runes runes | jq -r .runes.SUPERMA
 rune_id_arr=(${RUNE_ID//:/ })
 RUNE_BLOCK=${rune_id_arr[0]}
 RUNE_TX_ID=${rune_id_arr[1]}
+
+if [ -z "$RUNE_BLOCK" ] || [ -z "$RUNE_TX_ID" ]; then
+  echo "Failed to get rune id"
+  exit 1
+fi
 
 echo "Found rune id: ${RUNE_BLOCK}:${RUNE_TX_ID}"
 

--- a/src/minter-contract-utils/build.rs
+++ b/src/minter-contract-utils/build.rs
@@ -5,7 +5,6 @@ use solidity_helper::error::SolidityHelperError;
 use solidity_helper::{compile_solidity_contracts, SolidityContract};
 
 fn main() -> anyhow::Result<()> {
-    /*
     let contracts = match compile_solidity_contracts(None, None) {
         Ok(c) => c,
         Err(SolidityHelperError::IoError(err)) if err.kind() == ErrorKind::NotFound => {
@@ -47,7 +46,7 @@ fn main() -> anyhow::Result<()> {
         &contracts,
         "WatermelonToken",
         "BUILD_SMART_CONTRACT_TEST_WTM_HEX_CODE",
-    ); */
+    );
 
     Ok(())
 }

--- a/src/minter-contract-utils/build.rs
+++ b/src/minter-contract-utils/build.rs
@@ -5,6 +5,7 @@ use solidity_helper::error::SolidityHelperError;
 use solidity_helper::{compile_solidity_contracts, SolidityContract};
 
 fn main() -> anyhow::Result<()> {
+    /*
     let contracts = match compile_solidity_contracts(None, None) {
         Ok(c) => c,
         Err(SolidityHelperError::IoError(err)) if err.kind() == ErrorKind::NotFound => {
@@ -46,7 +47,7 @@ fn main() -> anyhow::Result<()> {
         &contracts,
         "WatermelonToken",
         "BUILD_SMART_CONTRACT_TEST_WTM_HEX_CODE",
-    );
+    ); */
 
     Ok(())
 }

--- a/src/rune-bridge/src/canister.rs
+++ b/src/rune-bridge/src/canister.rs
@@ -54,7 +54,7 @@ impl RuneBridge {
             self.update_metrics_timer(std::time::Duration::from_secs(METRICS_UPDATE_INTERVAL_SEC));
 
             const GLOBAL_TIMER_INTERVAL: Duration = Duration::from_secs(1);
-            const USED_UTXOS_REMOVE_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24 * 7); // 7 days
+            const USED_UTXOS_REMOVE_INTERVAL: Duration = Duration::from_secs(60 * 60 * 24); // once a day
 
             ic_exports::ic_cdk_timers::set_timer_interval(GLOBAL_TIMER_INTERVAL, move || {
                 get_scheduler()

--- a/src/rune-bridge/src/canister.rs
+++ b/src/rune-bridge/src/canister.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::str::FromStr;
-use std::time::Duration;
 
 use bitcoin::bip32::DerivationPath;
 use bitcoin::consensus::Encodable;

--- a/src/rune-bridge/src/canister.rs
+++ b/src/rune-bridge/src/canister.rs
@@ -68,10 +68,10 @@ impl RuneBridge {
                 }
             });
 
-            ic_exports::ic_cdk_timers::set_timer_interval(USED_UTXOS_REMOVE_INTERVAL, || async {
-                crate::task::RemoveUsedUtxosTask::from(get_state())
-                    .run()
-                    .await;
+            ic_exports::ic_cdk_timers::set_timer_interval(USED_UTXOS_REMOVE_INTERVAL, || {
+                ic_exports::ic_cdk::spawn(
+                    crate::task::RemoveUsedUtxosTask::from(get_state()).run(),
+                );
             });
         }
     }

--- a/src/rune-bridge/src/ledger.rs
+++ b/src/rune-bridge/src/ledger.rs
@@ -163,10 +163,11 @@ impl UtxoLedger {
         }
     }
 
-    /// Lists all utxos in the store.
-    pub fn load_all(&self) -> (Vec<UtxoKey>, Vec<TxInputInfo>) {
+    /// Lists all unspent utxos in the store.
+    pub fn load_unspent_utxos(&self) -> (Vec<UtxoKey>, Vec<TxInputInfo>) {
         self.utxo_storage
             .iter()
+            .filter(|(key, _)| !self.used_utxos_registry.contains_key(key))
             .map(|(key, details)| {
                 (
                     key,

--- a/src/rune-bridge/src/ledger.rs
+++ b/src/rune-bridge/src/ledger.rs
@@ -5,29 +5,34 @@ use bitcoin::hashes::sha256d::Hash;
 use bitcoin::{Address, Amount, OutPoint, TxOut, Txid};
 use candid::{CandidType, Decode, Encode};
 use ic_exports::ic_cdk::api::management_canister::bitcoin::{Outpoint, Utxo};
+use ic_exports::ic_kit::ic;
 use ic_stable_structures::stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::{BTreeMapStructure, Bound, StableBTreeMap, Storable, VirtualMemory};
 use ord_rs::wallet::TxInputInfo;
 use serde::Deserialize;
 
 use crate::key::{ic_dp_to_derivation_path, IcBtcSigner};
-use crate::memory::{LEDGER_MEMORY_ID, MEMORY_MANAGER};
+use crate::memory::{LEDGER_MEMORY_ID, MEMORY_MANAGER, USED_UTXOS_REGISTRY_MEMORY_ID};
 
 /// Data structure to keep track of utxos owned by the canister.
 pub struct UtxoLedger {
     utxo_storage: StableBTreeMap<UtxoKey, UtxoDetails, VirtualMemory<DefaultMemoryImpl>>,
+    used_utxos_registry: StableBTreeMap<UtxoKey, UsedUtxoDetails, VirtualMemory<DefaultMemoryImpl>>,
 }
 
 impl Default for UtxoLedger {
     fn default() -> Self {
         Self {
             utxo_storage: StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(LEDGER_MEMORY_ID))),
+            used_utxos_registry: StableBTreeMap::new(
+                MEMORY_MANAGER.with(|mm| mm.get(USED_UTXOS_REGISTRY_MEMORY_ID)),
+            ),
         }
     }
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, CandidType, Deserialize)]
-struct UtxoKey {
+pub struct UtxoKey {
     tx_id: [u8; 32],
     vout: u32,
 }
@@ -67,7 +72,7 @@ impl From<&Outpoint> for UtxoKey {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
-struct UtxoDetails {
+pub struct UtxoDetails {
     value: u64,
     script_buf: Vec<u8>,
     derivation_path: Vec<Vec<u8>>,
@@ -90,6 +95,27 @@ impl Storable for UtxoDetails {
 
     const BOUND: Bound = Bound::Bounded {
         max_size: size_of::<u64>() as u32 + Self::MAX_SCRIPT_SIZE + Self::DERIVATION_PATH_SIZE,
+        is_fixed_size: false,
+    };
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
+pub struct UsedUtxoDetails {
+    pub used_at: u64,
+}
+
+impl Storable for UsedUtxoDetails {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = Encode!(self).expect("failed to serialize utxo");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(&bytes, Self).expect("failed to deserialize utxo")
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: size_of::<u64>() as u32,
         is_fixed_size: false,
     };
 }
@@ -118,22 +144,55 @@ impl UtxoLedger {
     }
 
     /// Lists all utxos in the store.
-    pub fn load_all(&self) -> Vec<TxInputInfo> {
+    pub fn load_all(&self) -> (Vec<UtxoKey>, Vec<TxInputInfo>) {
         self.utxo_storage
             .iter()
-            .map(|(key, details)| TxInputInfo {
-                outpoint: OutPoint {
-                    txid: Txid::from_raw_hash(*Hash::from_bytes_ref(&key.tx_id)),
-                    vout: key.vout,
-                },
-                tx_out: TxOut {
-                    value: Amount::from_sat(details.value),
-                    script_pubkey: details.script_buf.into(),
-                },
-                derivation_path: ic_dp_to_derivation_path(&details.derivation_path)
-                    .expect("invalid derivation path"),
+            .map(|(key, details)| {
+                (
+                    key,
+                    TxInputInfo {
+                        outpoint: OutPoint {
+                            txid: Txid::from_raw_hash(*Hash::from_bytes_ref(&key.tx_id)),
+                            vout: key.vout,
+                        },
+                        tx_out: TxOut {
+                            value: Amount::from_sat(details.value),
+                            script_pubkey: details.script_buf.into(),
+                        },
+                        derivation_path: ic_dp_to_derivation_path(&details.derivation_path)
+                            .expect("invalid derivation path"),
+                    },
+                )
+            })
+            .unzip()
+    }
+
+    /// Marks the utxo as used.
+    pub fn mark_as_used(&mut self, key: UtxoKey) {
+        self.used_utxos_registry.insert(
+            key,
+            UsedUtxoDetails {
+                used_at: ic::time(),
+            },
+        );
+    }
+
+    /// Lists all used utxos in the store.
+    pub fn load_used_utxos(&self) -> Vec<(UtxoKey, UsedUtxoDetails, UtxoDetails)> {
+        self.used_utxos_registry
+            .iter()
+            .filter_map(|(key, used_details)| {
+                self.utxo_storage
+                    .get(&key)
+                    .map(|details| (key, used_details.clone(), details.clone()))
             })
             .collect()
+    }
+
+    /// Removes the utxo from the store.
+    pub fn remove_utxo(&mut self, key: &UtxoKey) {
+        self.utxo_storage.remove(key);
+        self.used_utxos_registry.remove(key);
     }
 }
 

--- a/src/rune-bridge/src/ledger.rs
+++ b/src/rune-bridge/src/ledger.rs
@@ -114,7 +114,7 @@ pub struct UsedUtxoDetails {
 }
 
 impl UsedUtxoDetails {
-    const MAX_BITCOIN_ADDRESS_SIZE: u32 = 42;
+    const MAX_BITCOIN_ADDRESS_SIZE: u32 = 96;
 
     /// Returns the owner address of the utxo.
     pub fn owner_address(&self, network: Network) -> Result<Address, Box<dyn std::error::Error>> {

--- a/src/rune-bridge/src/lib.rs
+++ b/src/rune-bridge/src/lib.rs
@@ -8,6 +8,7 @@ pub mod orders_store;
 pub mod rune_info;
 pub mod scheduler;
 pub mod state;
+pub mod task;
 
 use ic_metrics::Metrics;
 

--- a/src/rune-bridge/src/memory.rs
+++ b/src/rune-bridge/src/memory.rs
@@ -8,6 +8,7 @@ pub const MINT_ORDERS_MEMORY_ID: MemoryId = MemoryId::new(3);
 pub const LOGGER_SETTINGS_MEMORY_ID: MemoryId = MemoryId::new(4);
 pub const BURN_REQUEST_MEMORY_ID: MemoryId = MemoryId::new(5);
 pub const LEDGER_MEMORY_ID: MemoryId = MemoryId::new(6);
+pub const USED_UTXOS_REGISTRY_MEMORY_ID: MemoryId = MemoryId::new(7);
 
 thread_local! {
     pub static MEMORY_MANAGER: IcMemoryManager<DefaultMemoryImpl> = IcMemoryManager::init(DefaultMemoryImpl::default());

--- a/src/rune-bridge/src/ops.rs
+++ b/src/rune-bridge/src/ops.rs
@@ -164,7 +164,7 @@ pub async fn withdraw(
     rune_id: RuneId,
     address: Address,
 ) -> Result<Txid, WithdrawError> {
-    let (utxo_keys, current_utxos) = state.borrow().ledger().load_all();
+    let (utxo_keys, current_utxos) = state.borrow().ledger().load_unspent_utxos();
     let tx =
         build_withdraw_transaction(state, amount, address.clone(), rune_id, current_utxos).await?;
     send_tx(state, &tx).await?;

--- a/src/rune-bridge/src/rune_info.rs
+++ b/src/rune-bridge/src/rune_info.rs
@@ -1,10 +1,11 @@
+use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::str::FromStr;
+
 use candid::types::{Serializer, Type};
 use candid::{CandidType, Deserialize};
 use ordinals::{Rune, RuneId};
 use serde::Deserializer;
-use std::fmt::{Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::str::FromStr;
 
 #[derive(Debug, Copy, Clone, CandidType, Deserialize)]
 pub struct RuneInfo {

--- a/src/rune-bridge/src/state.rs
+++ b/src/rune-bridge/src/state.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bitcoin::bip32::ChainCode;
 use bitcoin::{Network, PrivateKey, PublicKey};
 use candid::{CandidType, Deserialize, Principal};
@@ -14,7 +16,6 @@ use minter_contract_utils::evm_bridge::{EvmInfo, EvmParams};
 use minter_contract_utils::evm_link::EvmLink;
 use ord_rs::wallet::LocalSigner;
 use ord_rs::Wallet;
-use std::collections::HashMap;
 
 use crate::key::IcBtcSigner;
 use crate::ledger::UtxoLedger;

--- a/src/rune-bridge/src/task.rs
+++ b/src/rune-bridge/src/task.rs
@@ -118,7 +118,7 @@ impl RemoveUsedUtxosTask {
                 filter: Some(filter),
             })
             .await
-            .map(|value| value.0)?;
+            .map(|(value,)| value)?;
 
             utxos.extend(response.utxos);
             match response.next_page {

--- a/src/rune-bridge/src/task.rs
+++ b/src/rune-bridge/src/task.rs
@@ -1,0 +1,31 @@
+use std::{cell::RefCell, rc::Rc, time::Duration};
+
+use crate::state::State;
+
+const EXPIRED_UTXO_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 3); // 3 days
+
+pub struct RemoveUsedUtxosTask {
+    state: Rc<RefCell<State>>,
+}
+
+impl From<Rc<RefCell<State>>> for RemoveUsedUtxosTask {
+    fn from(state: Rc<RefCell<State>>) -> Self {
+        Self { state }
+    }
+}
+
+impl RemoveUsedUtxosTask {
+    pub async fn run(self) {
+        let time_now = Duration::from_nanos(ic_exports::ic_cdk::api::time());
+        let utxos_to_check = self
+            .state
+            .borrow()
+            .ledger()
+            .load_used_utxos()
+            .into_iter()
+            .filter(|(_, details, _)| {
+                Duration::from_nanos(details.used_at) + EXPIRED_UTXO_TTL <= time_now
+            })
+            .collect::<Vec<_>>();
+    }
+}

--- a/src/rune-bridge/src/task.rs
+++ b/src/rune-bridge/src/task.rs
@@ -1,9 +1,21 @@
-use std::{cell::RefCell, rc::Rc, time::Duration};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::time::Duration;
 
+use ::bitcoin::Address;
+use ic_exports::ic_cdk::api::management_canister::bitcoin::{
+    self, BitcoinNetwork, GetUtxosRequest, Utxo, UtxoFilter,
+};
+use ic_exports::ic_kit::RejectionCode;
+
+use crate::ledger::UtxoKey;
 use crate::state::State;
 
 const EXPIRED_UTXO_TTL: Duration = Duration::from_secs(60 * 60 * 24 * 3); // 3 days
 
+/// Task to remove used UTXOs from the ledger.
+/// It also remark as available to be spent those utxos which haven't been spent for some reason.
 pub struct RemoveUsedUtxosTask {
     state: Rc<RefCell<State>>,
 }
@@ -15,6 +27,7 @@ impl From<Rc<RefCell<State>>> for RemoveUsedUtxosTask {
 }
 
 impl RemoveUsedUtxosTask {
+    /// Run the task.
     pub async fn run(self) {
         let time_now = Duration::from_nanos(ic_exports::ic_cdk::api::time());
         let utxos_to_check = self
@@ -23,9 +36,100 @@ impl RemoveUsedUtxosTask {
             .ledger()
             .load_used_utxos()
             .into_iter()
-            .filter(|(_, details, _)| {
+            .filter(|(_, details)| {
                 Duration::from_nanos(details.used_at) + EXPIRED_UTXO_TTL <= time_now
             })
             .collect::<Vec<_>>();
+
+        let network = self.state.borrow().network();
+        let mut utxos_by_owner = HashMap::new();
+        for (key, used_utxo_info) in utxos_to_check {
+            // try to get the previous owner address of the utxo; otherwise remove it
+            let owner_address = match used_utxo_info.owner_address(network) {
+                Ok(address) => address,
+                Err(err) => {
+                    log::error!("invalid owner address: {}; removing used utxo", err);
+                    self.state.borrow_mut().ledger_mut().remove_spent_utxo(&key);
+                    continue;
+                }
+            };
+            // insert the utxo into the owner's list
+            utxos_by_owner
+                .entry(owner_address)
+                .or_insert_with(Vec::new)
+                .push(key);
+        }
+
+        // iter owners
+        let btc_network = self.state.borrow().ic_btc_network();
+        for (owner, utxos) in utxos_by_owner {
+            let owner_utxos = match Self::get_owner_utxos(&owner, btc_network).await {
+                Ok(utxos) => utxos,
+                Err((code, msg)) => {
+                    log::error!("failed to get owner {owner} utxos: {msg} ({code:?})");
+                    continue;
+                }
+            };
+            // get spent utxos
+            utxos
+                .into_iter()
+                .for_each(|key| self.remove_used_utxo(&key, &owner_utxos));
+        }
+    }
+
+    /// Check whether the provided UTXO is spent or not.
+    ///
+    /// If the UTXO is spent, it will be removed from the ledger.
+    /// Otherwise, the UTXO will be removed only from the used UTXOs registry.
+    fn remove_used_utxo(&self, used_utxo_key: &UtxoKey, owner_utxos: &[Utxo]) {
+        let is_utxo_spent = !owner_utxos.iter().any(|owner_utxo| {
+            owner_utxo.outpoint.txid == used_utxo_key.tx_id
+                && owner_utxo.outpoint.vout == used_utxo_key.vout
+        });
+
+        if is_utxo_spent {
+            self.state
+                .borrow_mut()
+                .ledger_mut()
+                .remove_spent_utxo(used_utxo_key);
+            log::info!("removed spent utxo: {used_utxo_key}");
+        } else {
+            // mark as unspent
+            self.state
+                .borrow_mut()
+                .ledger_mut()
+                .remove_unspent_utxo(used_utxo_key);
+            log::info!("marked unspent utxo: {used_utxo_key}");
+        }
+    }
+
+    /// Get all UTXOs owned by the given owner.
+    async fn get_owner_utxos(
+        owner: &Address,
+        btc_network: BitcoinNetwork,
+    ) -> Result<Vec<Utxo>, (RejectionCode, String)> {
+        log::debug!("getting utxos for owner {owner}");
+        let mut filter = UtxoFilter::MinConfirmations(6);
+        let mut utxos = vec![];
+        loop {
+            let response = bitcoin::bitcoin_get_utxos(GetUtxosRequest {
+                address: owner.to_string(),
+                network: btc_network,
+                filter: Some(filter),
+            })
+            .await
+            .map(|value| value.0)?;
+
+            utxos.extend(response.utxos);
+            match response.next_page {
+                None => break,
+                Some(page) => {
+                    filter = UtxoFilter::Page(page);
+                }
+            }
+        }
+
+        log::debug!("got {} utxos for owner {owner}", utxos.len());
+        Ok(utxos)
     }
 }


### PR DESCRIPTION
- **wip**
- **EPROD-866 remove spent utxos from ledger**

## Issue ticket

Issue ticket link:


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
