### PR TITLE
[EPROD-906] BftBridge ring buffer moved to library

### DIFF
--- a/solidity/remappings.txt
+++ b/solidity/remappings.txt
@@ -1,1 +1,2 @@
 openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
+forge-std/=lib/forge-std/src/

--- a/solidity/src/BftBridge.sol
+++ b/solidity/src/BftBridge.sol
@@ -63,23 +63,6 @@ contract BFTBridge {
         }
     }
 
-    function toIDfromBaseAddress(
-        uint32 chainID,
-        address toAddress
-    ) public pure returns (bytes32 toID) {
-        return
-            bytes32(
-            abi.encodePacked(
-                uint8(1),
-                chainID,
-                toAddress,
-                uint32(0),
-                uint16(0),
-                uint(8)
-            )
-        );
-    }
-
     // Additional gas amount for fee charge.
     uint256 constant additionalGasFee = 1000;
 

--- a/solidity/src/contract_tests/BftBridge.t.sol
+++ b/solidity/src/contract_tests/BftBridge.t.sol
@@ -36,40 +36,10 @@ contract BftBridgeTest is Test {
     address _bob = vm.addr(_BOB_KEY);
 
     BFTBridge _bridge;
-    BFTBridge.RingBuffer _buffer;
 
     function setUp() public {
         vm.chainId(_CHAIN_ID);
         _bridge = new BFTBridge(_owner);
-    }
-
-    function testIncrementRingBuffer() public {
-        assertEq(_bridge.size(_buffer), 0);
-
-        for (uint32 i = 1; i < 256; i += 1) {
-            _buffer = _bridge.increment(_buffer);
-            assertEq(_buffer.begin, 0);
-            assertEq(_buffer.end, uint8(i));
-            assertEq(_bridge.size(_buffer), uint8(i));
-        }
-
-        _buffer = _bridge.increment(_buffer);
-        assertEq(_buffer.begin, 1);
-        assertEq(_buffer.end, uint8(0));
-        assertEq(_bridge.size(_buffer), uint8(255));
-
-        _buffer = _bridge.increment(_buffer);
-        assertEq(_buffer.begin, 2);
-        assertEq(_buffer.end, uint8(1));
-        assertEq(_bridge.size(_buffer), uint8(255));
-
-        _buffer.begin = 255;
-        _buffer.end = 254;
-
-        _buffer = _bridge.increment(_buffer);
-        assertEq(_buffer.begin, 0);
-        assertEq(_buffer.end, uint8(255));
-        assertEq(_bridge.size(_buffer), uint8(255));
     }
 
     function bytes32ToString(bytes32 _bytes32) public pure returns (string memory) {

--- a/solidity/src/libraries/RingBuffer.sol
+++ b/solidity/src/libraries/RingBuffer.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
+
+
+library RingBuffer {
+    struct RingBufferUint32 {
+        uint8 begin;
+        uint8 end;
+        mapping(uint8 => uint32) values;    
+    }
+
+    // Append the value to the ring buffer.
+    function push(RingBufferUint32 storage buffer, uint32 value) internal {
+        buffer.values[buffer.end] = value;
+
+        unchecked {
+            buffer.end++;
+        }
+
+        if (buffer.begin == buffer.end) {
+            unchecked {
+                buffer.begin++;
+            }
+        }
+    }
+
+    // Function to get the size of the buffer.
+    function size(RingBufferUint32 storage buffer) internal view returns (uint8 sizeOf) {
+        if (buffer.begin <= buffer.end) {
+            sizeOf = buffer.end - buffer.begin;
+        } else {
+            sizeOf = 255;
+        }
+    }
+
+    // Returns all values in order of pushing.
+    function getAll(RingBufferUint32 storage buffer) internal view returns (uint32[] memory values) {
+        uint8 _size = size(buffer);
+        values = new uint32[](_size);
+        for (uint8 i = 0; i < _size; i++) {
+            uint8 offset;
+            unchecked {
+                offset = buffer.begin + i;
+            }
+            uint32 value = buffer.values[offset];
+            values[i] = value;
+        }
+    }
+}
+

--- a/solidity/src/libraries_tests/RingBuffer.t.sol
+++ b/solidity/src/libraries_tests/RingBuffer.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
+
+import "forge-std/Test.sol";
+import "forge-std/console.sol";
+import {RingBuffer} from "src/libraries/RingBuffer.sol";
+
+contract RingBufferTests is Test {
+    using RingBuffer for RingBuffer.RingBufferUint32;
+
+    RingBuffer.RingBufferUint32 _buffer;
+
+
+    function testIncrementRingBuffer() public {
+        assertEq(_buffer.size(), 0);
+
+        for (uint32 i = 1; i < 256; i += 1) {
+            _buffer.push(i);
+            assertEq(_buffer.size(), i);
+            assertEq(_buffer.getAll().length, i);
+        }
+        assertEq(_buffer.getAll()[0], 1);
+
+        _buffer.push(300);
+        assertEq(_buffer.size(), 255);
+        assertEq(_buffer.getAll()[0], 2);
+        assertEq(_buffer.getAll()[254], 300);
+
+        _buffer.push(301);
+        assertEq(_buffer.size(), 255);
+        assertEq(_buffer.getAll()[0], 3);
+        assertEq(_buffer.getAll()[254], 301);
+
+        _buffer.push(302);
+        assertEq(_buffer.size(), 255);
+        assertEq(_buffer.getAll()[0], 4);
+        assertEq(_buffer.getAll()[254], 302);
+    }
+}

--- a/src/icrc2-minter/src/canister.rs
+++ b/src/icrc2-minter/src/canister.rs
@@ -257,7 +257,7 @@ impl MinterCanister {
     }
 
     /// Starts the BFT bridge contract deployment.
-    // #[update]
+    #[update]
     pub async fn init_bft_bridge_contract(&mut self) -> Result<H256> {
         let state = get_state();
         let signer = state.borrow().signer.get_transaction_signer();

--- a/src/icrc2-minter/src/canister.rs
+++ b/src/icrc2-minter/src/canister.rs
@@ -257,7 +257,7 @@ impl MinterCanister {
     }
 
     /// Starts the BFT bridge contract deployment.
-    #[update]
+    // #[update]
     pub async fn init_bft_bridge_contract(&mut self) -> Result<H256> {
         let state = get_state();
         let signer = state.borrow().signer.get_transaction_signer();
@@ -291,8 +291,8 @@ impl MinterCanister {
             .set_bft_bridge_contract_status(status);
 
         let options = TaskOptions::default()
-            .with_max_retries_policy(u32::MAX)
-            .with_fixed_backoff_policy(4);
+            .with_retry_policy(ic_task_scheduler::retry::RetryPolicy::Infinite)
+            .with_fixed_backoff_policy(2);
         get_scheduler()
             .borrow_mut()
             .append_task(ScheduledTask::with_options(


### PR DESCRIPTION
## Issue ticket

Issue ticket link:
https://infinityswap.atlassian.net/browse/EPROD-906

## Checklist before requesting a review

### Code conventions

- [X] I have performed a self-review of my code
- [X] Every new function is documented
- [X] Object names are auto explicative
- [X] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [X] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [X] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [X] The PR does not break APIs backward compatibility
- [X] The PR does not break the stable storage backward compatibility


### Testing 

- [X] Every function is properly unit tested
- [X] I have added integration tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] IC endpoints are always tested through the `canister_call!` macro
