### PR TITLE
Modify BftBridge to allow minter notifications

### DIFF
--- a/solidity/src/BftBridge.sol
+++ b/solidity/src/BftBridge.sol
@@ -144,6 +144,15 @@ contract BFTBridge {
         uint8 decimals;
     }
 
+    event NotifyMinterEvent(
+        uint32 notificationType,
+        bytes userData
+    );
+
+    function notifyMinter(uint32 calldata notificationType, bytes calldata userData) external {
+        emit NotifyMinterEvent(notificationType, userData);
+    }
+
     // Deposit `msg.value` amount of native token to user's address.
     // The deposit could be used to pay fees.
     // Returns user's balance after the operation.
@@ -160,7 +169,7 @@ contract BFTBridge {
         _userNativeDeposit[to] = balance;
         payable(minterCanisterAddress).transfer(msg.value);
     }
-    
+
     // Remove approved SpenderIDs
     function removeApprovedSenderIDs(bytes32[] calldata approvedSenderIDs) external {
         for (uint i = 0; i < approvedSenderIDs.length; i++) {
@@ -169,7 +178,7 @@ contract BFTBridge {
     }
 
     // Returns user's native token deposit balance. 
-    function nativeTokenBalance(address user) external view returns(uint256 balance) {
+    function nativeTokenBalance(address user) external view returns (uint256 balance) {
         if (user == address(0)) {
             user = msg.sender;
         }

--- a/solidity/src/BftBridge.sol
+++ b/solidity/src/BftBridge.sol
@@ -144,11 +144,14 @@ contract BFTBridge {
         uint8 decimals;
     }
 
+    // Event that can be emited with a notification for the minter canister
     event NotifyMinterEvent(
         uint32 notificationType,
         bytes userData
     );
 
+    // Emit minter notification event with the given `userData`. For details about what should be in the user data,
+    // check the implementation of the corresponding minter.
     function notifyMinter(uint32 calldata notificationType, bytes calldata userData) external {
         emit NotifyMinterEvent(notificationType, userData);
     }

--- a/solidity/src/BftBridge.sol
+++ b/solidity/src/BftBridge.sol
@@ -152,7 +152,7 @@ contract BFTBridge {
 
     // Emit minter notification event with the given `userData`. For details about what should be in the user data,
     // check the implementation of the corresponding minter.
-    function notifyMinter(uint32 calldata notificationType, bytes calldata userData) external {
+    function notifyMinter(uint32 notificationType, bytes calldata userData) external {
         emit NotifyMinterEvent(notificationType, userData);
     }
 

--- a/src/btc-bridge/src/scheduler.rs
+++ b/src/btc-bridge/src/scheduler.rs
@@ -132,6 +132,7 @@ impl BtcTask {
                 let remove_mint_order_task = BtcTask::RemoveMintOrder(minted);
                 return Some(remove_mint_order_task.into_scheduled(options));
             }
+            Ok(BridgeEvent::Notify(_)) => todo!(),
             Err(e) => log::warn!("collected log is incompatible with expected events: {e}"),
         }
 

--- a/src/erc20-minter/src/tasks.rs
+++ b/src/erc20-minter/src/tasks.rs
@@ -258,6 +258,7 @@ impl BridgeTask {
                 let remove_mint_order_task = BridgeTask::RemoveMintOrder(minted);
                 return Some(remove_mint_order_task.into_scheduled(options));
             }
+            Ok(BridgeEvent::Notify(_)) => todo!(),
             Err(e) => log::warn!("collected log is incompatible with expected events: {e}"),
         }
 

--- a/src/icrc2-minter/src/tasks.rs
+++ b/src/icrc2-minter/src/tasks.rs
@@ -253,6 +253,7 @@ impl BridgeTask {
                 let remove_mint_order_task = BridgeTask::RemoveMintOrder(minted);
                 return Some(remove_mint_order_task.into_scheduled(options));
             }
+            Ok(BridgeEvent::Notify(_)) => todo!(),
             Err(e) => log::warn!("collected log is incompatible with expected events: {e}"),
         }
 

--- a/src/minter-contract-utils/src/bft_bridge_api.rs
+++ b/src/minter-contract-utils/src/bft_bridge_api.rs
@@ -229,6 +229,7 @@ pub static BURNT_EVENT: Lazy<Event> = Lazy::new(|| Event {
 pub enum BridgeEvent {
     Burnt(BurntEventData),
     Minted(MintedEventData),
+    Notify(NotifyMinterEventData),
 }
 
 impl BridgeEvent {
@@ -245,6 +246,7 @@ impl BridgeEvent {
             topics: Some(vec![vec![
                 BURNT_EVENT.signature(),
                 MINTED_EVENT.signature(),
+                NOTIFY_EVENT.signature(),
             ]]),
         };
 
@@ -267,7 +269,8 @@ impl TryFrom<RawLog> for BridgeEvent {
     fn try_from(log: RawLog) -> Result<Self, Self::Error> {
         BurntEventData::try_from(log.clone())
             .map(Self::Burnt)
-            .or_else(|_| MintedEventData::try_from(log).map(Self::Minted))
+            .or_else(|_| MintedEventData::try_from(log.clone()).map(Self::Minted))
+            .or_else(|_| NotifyMinterEventData::try_from(log).map(Self::Notify))
     }
 }
 
@@ -283,6 +286,11 @@ pub struct BurntEventData {
     pub name: Vec<u8>,
     pub symbol: Vec<u8>,
     pub decimals: u8,
+}
+
+fn not_found(field: &str) -> impl FnOnce() -> ethers_core::abi::Error {
+    let msg = format!("missing event field `{}`", field);
+    move || ethers_core::abi::Error::Other(msg.into())
 }
 
 /// Builds `BurntEventData` from tokens.
@@ -303,11 +311,6 @@ impl BurntEventDataBuilder {
     /// Builds `BurntEventData` from tokens.
     /// All fields are required.
     fn build(self) -> Result<BurntEventData, ethers_core::abi::Error> {
-        fn not_found(field: &str) -> impl FnOnce() -> ethers_core::abi::Error {
-            let msg = format!("missing event field `{}`", field);
-            move || ethers_core::abi::Error::Other(msg.into())
-        }
-
         Ok(BurntEventData {
             sender: self.sender.ok_or_else(not_found("sender"))?.into(),
             amount: self.amount.ok_or_else(not_found("amount"))?.into(),
@@ -391,6 +394,23 @@ pub static MINTED_EVENT: Lazy<Event> = Lazy::new(|| Event {
     anonymous: false,
 });
 
+pub static NOTIFY_EVENT: Lazy<Event> = Lazy::new(|| Event {
+    name: "NotifyMinterEvent".into(),
+    inputs: vec![
+        EventParam {
+            name: "notificationType".into(),
+            kind: ParamType::Uint(32),
+            indexed: false,
+        },
+        EventParam {
+            name: "userData".into(),
+            kind: ParamType::Bytes,
+            indexed: false,
+        },
+    ],
+    anonymous: false,
+});
+
 /// Event emitted when token is minted by BFTBridge.
 #[derive(Debug, Default, Clone, CandidType, Serialize, Deserialize)]
 pub struct MintedEventData {
@@ -417,11 +437,6 @@ impl MintedEventDataBuilder {
     /// Builds `MintedEventData` from tokens.
     /// All fields are required.
     fn build(self) -> Result<MintedEventData, ethers_core::abi::Error> {
-        fn not_found(field: &str) -> impl FnOnce() -> ethers_core::abi::Error {
-            let msg = format!("missing event field `{}`", field);
-            move || ethers_core::abi::Error::Other(msg.into())
-        }
-
         Ok(MintedEventData {
             amount: self.amount.ok_or_else(not_found("amount"))?.into(),
             from_token: self.from_token.ok_or_else(not_found("fromToken"))?,
@@ -453,6 +468,57 @@ impl TryFrom<RawLog> for MintedEventData {
         let parsed = MINTED_EVENT.parse_log(log)?;
 
         let mut data_builder = MintedEventDataBuilder::default();
+
+        for param in parsed.params {
+            data_builder = data_builder.with_field_from_token(&param.name, param.value);
+        }
+
+        data_builder.build()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, CandidType, Serialize, Deserialize)]
+pub struct NotifyMinterEventData {
+    pub notification_type: u32,
+    pub user_data: Vec<u8>,
+}
+
+struct NotifyMinterEventDataBuilder {
+    notification_type: Option<u32>,
+    user_data: Option<Vec<u8>>,
+}
+
+impl Default for NotifyMinterEventDataBuilder {
+    fn default() -> Self {
+        Self { user_data: None, notification_type: None }
+    }
+}
+
+impl NotifyMinterEventDataBuilder {
+    fn build(self) -> Result<NotifyMinterEventData, ethers_core::abi::Error> {
+        Ok(NotifyMinterEventData {
+            notification_type: self.notification_type.ok_or_else(not_found("notificationType"))?.into(),
+            user_data: self.user_data.ok_or_else(not_found("userData"))?.into(),
+        })
+    }
+
+    fn with_field_from_token(mut self, name: &str, value: Token) -> Self {
+        match name {
+            "notificationType" => self.notification_type = value.into_uint().map(|v| v.as_u32()),
+            "userData" => self.user_data = value.into_bytes().map(Into::into),
+            _ => {}
+        };
+        self
+    }
+}
+
+impl TryFrom<RawLog> for NotifyMinterEventData {
+    type Error = ethers_core::abi::Error;
+
+    fn try_from(log: RawLog) -> Result<Self, Self::Error> {
+        let parsed = NOTIFY_EVENT.parse_log(log)?;
+
+        let mut data_builder = NotifyMinterEventDataBuilder::default();
 
         for param in parsed.params {
             data_builder = data_builder.with_field_from_token(&param.name, param.value);

--- a/src/minter-contract-utils/src/bft_bridge_api.rs
+++ b/src/minter-contract-utils/src/bft_bridge_api.rs
@@ -483,18 +483,10 @@ pub struct NotifyMinterEventData {
     pub user_data: Vec<u8>,
 }
 
+#[derive(Debug, Default, Clone)]
 struct NotifyMinterEventDataBuilder {
     notification_type: Option<u32>,
     user_data: Option<Vec<u8>>,
-}
-
-impl Default for NotifyMinterEventDataBuilder {
-    fn default() -> Self {
-        Self {
-            user_data: None,
-            notification_type: None,
-        }
-    }
 }
 
 impl NotifyMinterEventDataBuilder {
@@ -502,9 +494,8 @@ impl NotifyMinterEventDataBuilder {
         Ok(NotifyMinterEventData {
             notification_type: self
                 .notification_type
-                .ok_or_else(not_found("notificationType"))?
-                .into(),
-            user_data: self.user_data.ok_or_else(not_found("userData"))?.into(),
+                .ok_or_else(not_found("notificationType"))?,
+            user_data: self.user_data.ok_or_else(not_found("userData"))?,
         })
     }
 

--- a/src/minter-contract-utils/src/bft_bridge_api.rs
+++ b/src/minter-contract-utils/src/bft_bridge_api.rs
@@ -490,14 +490,20 @@ struct NotifyMinterEventDataBuilder {
 
 impl Default for NotifyMinterEventDataBuilder {
     fn default() -> Self {
-        Self { user_data: None, notification_type: None }
+        Self {
+            user_data: None,
+            notification_type: None,
+        }
     }
 }
 
 impl NotifyMinterEventDataBuilder {
     fn build(self) -> Result<NotifyMinterEventData, ethers_core::abi::Error> {
         Ok(NotifyMinterEventData {
-            notification_type: self.notification_type.ok_or_else(not_found("notificationType"))?.into(),
+            notification_type: self
+                .notification_type
+                .ok_or_else(not_found("notificationType"))?
+                .into(),
             user_data: self.user_data.ok_or_else(not_found("userData"))?.into(),
         })
     }

--- a/src/rune-bridge/src/scheduler.rs
+++ b/src/rune-bridge/src/scheduler.rs
@@ -134,6 +134,7 @@ impl RuneBridgeTask {
                 let remove_mint_order_task = RuneBridgeTask::RemoveMintOrder(minted);
                 return Some(remove_mint_order_task.into_scheduled(options));
             }
+            Ok(BridgeEvent::Notify(_)) => todo!(),
             Err(e) => log::warn!("collected log is incompatible with expected events: {e}"),
         }
 


### PR DESCRIPTION
This PR includes changes to the BftBridge contract and corresponding API, that can be used in all bridges to trigger scheduled events.

## Issue ticket

Issue ticket link: 
* https://infinityswap.atlassian.net/browse/EPROD-870


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
