### PR TITLE
EPROD-885 BFT tokenid ignored in burn events allow minting out of thin air

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ rust-toolchain.toml
 # solidity-coverage files
 */coverage
 */coverage.json
+
+solidity/build-info

--- a/scripts/deploy/erc20-bridge.sh
+++ b/scripts/deploy/erc20-bridge.sh
@@ -13,8 +13,8 @@ function usage() {
   echo "  -m, --install-mode <mode>                       Install mode (create, init, reinstall, upgrade)"
   echo "  --base-evm <canister-id>                        Base EVM link canister ID"
   echo "  --wrapped-evm <canister-id>                     Wrapped EVM link canister ID"
-  echo "  --erc20-base-bridge-contract <canister-id>      ERC20 Base bridge contract canister ID"
-  echo "  --erc20-wrapped-bridge-contract <canister-id>   ERC20 Wrapped bridge contract canister ID"
+  echo "  --erc20-base-bridge-contract <address>          ERC20 Base bridge contract address"
+  echo "  --erc20-wrapped-bridge-contract <address>       ERC20 Wrapped bridge contract address"
 }
 
 ARGS=$(getopt -o e:i:m:h --long evm-principal,ic-network,install-mode,base-evm,wrapped-evm,erc20-base-bridge-contract,erc20-wrapped-bridge-contract,help -- "$@")


### PR DESCRIPTION
## Issue ticket

Issue ticket link:


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
