### PR TITLE
Add some unit tests for bridge canister trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "bridge-did",
  "bridge-utils",
  "candid",
+ "cfg-if 1.0.0",
  "did 0.27.0",
  "env_logger",
  "eth-signer 0.27.0",
@@ -898,7 +899,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "vergen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "bridge-did",
  "bridge-utils",
  "candid",
+ "cfg-if 1.0.0",
  "did",
  "env_logger",
  "eth-signer",
@@ -898,7 +899,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "vergen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ async-recursion = "1.0.4"
 async-trait = "0.1"
 bitcoin = "0.31"
 candid = { version = "0.10", features = ["value"] }
+cfg-if = "1.0"
 clap = { version = "4", features = ["derive"] }
 did = { git = "https://github.com/bitfinity-network/bitfinity-evm-sdk", package = "did", tag = "v0.26.x" }
 env_logger = { version = "0.11", default-features = false }

--- a/src/bridge-canister/Cargo.toml
+++ b/src/bridge-canister/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 bridge-did = { path = "../bridge-did" }
 bridge-utils = { path = "../bridge-utils" }
 candid = { workspace = true }
+cfg-if = { workspace = true }
 did = { workspace = true }
 ethereum-json-rpc-client = { workspace = true, features = [
     "ic-canister-client",
@@ -38,10 +39,8 @@ thiserror = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }
-vergen = { workspace = true }
 
 [dev-dependencies]
-candid = { workspace = true }
 env_logger = { workspace = true }
 ic-exports = { workspace = true }
 tokio = { workspace = true }

--- a/src/bridge-canister/src/canister.rs
+++ b/src/bridge-canister/src/canister.rs
@@ -462,8 +462,7 @@ mod tests {
     #[tokio::test]
     #[should_panic(expected = "Running this method is only allowed for the owner of the canister")]
     async fn ic_logs_is_rejected_for_non_owner() {
-        let mut canister = init_canister().await;
-
+        let canister = init_canister().await;
         let _ = canister_call!(canister.ic_logs(1000, 0), ()).await;
     }
 }

--- a/src/bridge-canister/src/core.rs
+++ b/src/bridge-canister/src/core.rs
@@ -33,6 +33,7 @@ impl BridgeCore {
     /// * If the canister cannot initialize the transaction signer with the given parameters.
     pub fn init(&mut self, init_data: &BridgeInitData) {
         self.inspect_new_owner_is_valid(init_data.owner);
+        self.inspect_new_evm_is_valid(init_data.evm_principal);
         self.config = BridgeConfig::init(init_data);
         self.init_signer(0)
             .expect("Failed to initialize transaction signer.");
@@ -93,6 +94,16 @@ impl BridgeCore {
     fn inspect_new_owner_is_valid(&self, new_owner: Principal) {
         if new_owner == Principal::anonymous() {
             ic::trap("Owner cannot be an anonymous");
+        }
+    }
+
+    fn inspect_new_evm_is_valid(&self, new_evm: Principal) {
+        if new_evm == Principal::anonymous() {
+            ic::trap("Evm principal cannot be an anonymous");
+        }
+
+        if new_evm == Principal::management_canister() {
+            ic::trap("Evm principal cannot be management canister");
         }
     }
 

--- a/src/bridge-canister/src/lib.rs
+++ b/src/bridge-canister/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 //! Implementation of the common functions for BFT bridge canisters. The main entry point is
 //! [`BridgeCanister`] trait that should be implemented by a canister to include common APIs and
 //! functions.

--- a/src/icrc2-minter/src/canister.rs
+++ b/src/icrc2-minter/src/canister.rs
@@ -315,7 +315,7 @@ mod test {
 
         let init_data = BridgeInitData {
             owner: owner(),
-            evm_principal: Principal::anonymous(),
+            evm_principal: Principal::from_slice(&[2; 20]),
             signing_strategy: SigningStrategy::Local {
                 private_key: [1u8; 32],
             },
@@ -337,7 +337,7 @@ mod test {
         let stored_evm = canister_call!(canister.get_evm_principal(), Principal)
             .await
             .unwrap();
-        assert_eq!(stored_evm, Principal::anonymous());
+        assert_eq!(stored_evm, Principal::from_slice(&[2; 20]));
     }
 
     #[tokio::test]

--- a/src/integration-tests/tests/context/mod.rs
+++ b/src/integration-tests/tests/context/mod.rs
@@ -845,7 +845,10 @@ pub trait TestContext {
             }
             CanisterType::Icrc2Minter => {
                 println!("Installing default Minter canister...");
-                let evm_canister = self.canisters().get_or_anonymous(CanisterType::Evm);
+                let evm_canister = self
+                    .canisters()
+                    .get(CanisterType::Evm)
+                    .unwrap_or_else(|| Principal::from_slice(&[1; 20]));
                 let init_data = minter_canister_init_data(self.admin(), evm_canister);
                 self.install_canister(self.canisters().icrc2_minter(), wasm, (init_data,))
                     .await

--- a/src/integration-tests/tests/context/mod.rs
+++ b/src/integration-tests/tests/context/mod.rs
@@ -64,6 +64,9 @@ pub trait TestContext {
     /// Principal to use for canisters initialization.
     fn admin_name(&self) -> &str;
 
+    /// Signing key to use for management canister signing.
+    fn sign_key(&self) -> SigningKeyId;
+
     /// Returns the base EVM LINK
     fn base_evm_link(&self) -> EvmLink {
         EvmLink::Ic(self.canisters().external_evm())
@@ -896,7 +899,8 @@ pub trait TestContext {
                     .canisters()
                     .get(CanisterType::Evm)
                     .unwrap_or_else(|| Principal::from_slice(&[1; 20]));
-                let init_data = minter_canister_init_data(self.admin(), evm_canister);
+                let init_data =
+                    minter_canister_init_data(self.admin(), evm_canister, self.sign_key());
                 self.install_canister(self.canisters().icrc2_minter(), wasm, (init_data,))
                     .await
                     .unwrap();
@@ -951,7 +955,7 @@ pub trait TestContext {
                     base_evm_link: self.base_evm_link(),
                     wrapped_evm_link: EvmLink::Ic(evm_canister),
                     signing_strategy: SigningStrategy::ManagementCanister {
-                        key_id: SigningKeyId::PocketIc,
+                        key_id: self.sign_key(),
                     },
                     log_settings: Some(LogSettings {
                         enable_console: true,
@@ -1021,7 +1025,8 @@ pub trait TestContext {
 
     async fn reinstall_minter_canister(&self) -> Result<()> {
         eprintln!("reinstalling Minter canister");
-        let init_data = minter_canister_init_data(self.admin(), self.canisters().evm());
+        let init_data =
+            minter_canister_init_data(self.admin(), self.canisters().evm(), self.sign_key());
 
         let wasm = get_icrc2_minter_canister_bytecode().await;
         self.reinstall_canister(self.canisters().icrc2_minter(), wasm, (init_data,))
@@ -1069,13 +1074,15 @@ pub fn icrc_canister_default_init_args(
     }
 }
 
-pub fn minter_canister_init_data(owner: Principal, evm_principal: Principal) -> BridgeInitData {
+pub fn minter_canister_init_data(
+    owner: Principal,
+    evm_principal: Principal,
+    key_id: SigningKeyId,
+) -> BridgeInitData {
     BridgeInitData {
         owner,
         evm_principal,
-        signing_strategy: SigningStrategy::ManagementCanister {
-            key_id: SigningKeyId::PocketIc,
-        },
+        signing_strategy: SigningStrategy::ManagementCanister { key_id },
         log_settings: Some(LogSettings {
             enable_console: true,
             in_memory_records: None,

--- a/src/integration-tests/tests/dfx_tests/mod.rs
+++ b/src/integration-tests/tests/dfx_tests/mod.rs
@@ -4,6 +4,7 @@ use alloy_sol_types::sol;
 use bridge_utils::evm_link::{EvmLink, RpcApi, RpcService};
 use candid::utils::ArgumentEncoder;
 use candid::{Nat, Principal};
+use eth_signer::ic_sign::SigningKeyId;
 use ic_canister_client::IcAgentClient;
 use ic_exports::icrc_types::icrc1::account::Account;
 use ic_test_utils::{get_agent, Agent, Canister};
@@ -186,5 +187,9 @@ impl TestContext for DfxTestContext {
 
     fn icrc_token_initial_balances(&self) -> Vec<(Account, Nat)> {
         todo!()
+    }
+
+    fn sign_key(&self) -> SigningKeyId {
+        SigningKeyId::Dfx
     }
 }

--- a/src/integration-tests/tests/pocket_ic_integration_test/mod.rs
+++ b/src/integration-tests/tests/pocket_ic_integration_test/mod.rs
@@ -9,6 +9,7 @@ use alloy_sol_types::sol;
 use candid::utils::ArgumentEncoder;
 use candid::{Nat, Principal};
 use did::{TransactionReceipt, H160, H256};
+use eth_signer::ic_sign::SigningKeyId;
 use eth_signer::{Signer, Wallet};
 use ethers_core::k256::ecdsa::SigningKey;
 use evm_canister_client::EvmCanisterClient;
@@ -192,6 +193,10 @@ impl TestContext for PocketIcTestContext {
             (Account::from(john()), Nat::from(ICRC1_INITIAL_BALANCE)),
             (Account::from(alice()), Nat::from(ICRC1_INITIAL_BALANCE)),
         ]
+    }
+
+    fn sign_key(&self) -> SigningKeyId {
+        SigningKeyId::PocketIc
     }
 }
 

--- a/src/integration-tests/tests/state_machine_tests/mod.rs
+++ b/src/integration-tests/tests/state_machine_tests/mod.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use candid::utils::ArgumentEncoder;
 use candid::{encode_args, CandidType, Decode, Nat, Principal};
+use eth_signer::ic_sign::SigningKeyId;
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_canister_client::{CanisterClient, CanisterClientResult};
 use ic_exports::ic_kit::mock_principals::{alice, bob};
@@ -64,6 +65,10 @@ impl<'a> TestContext for &'a StateMachineContext {
 
     fn admin_name(&self) -> &str {
         "admin"
+    }
+
+    fn sign_key(&self) -> SigningKeyId {
+        todo!()
     }
 
     async fn advance_time(&self, time: Duration) {


### PR DESCRIPTION
Just add some unit tests for bridge canister trait APIs + add a method to get current logger settings

## Issue ticket

Issue ticket link:


## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative
- [x] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [x] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [x] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility


### Testing 

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
