### PR TITLE
Remove `set_evm_principal` method

### DIFF
--- a/src/bridge-canister/src/canister.rs
+++ b/src/bridge-canister/src/canister.rs
@@ -76,19 +76,6 @@ pub trait BridgeCanister: Canister {
         self.core().borrow().config.get_evm_principal()
     }
 
-    /// Sets principal of EVM canister with which the minter canister works.
-    ///
-    /// This method should be called only by current owner,
-    /// else `Error::NotAuthorised` will be returned.
-    #[update(trait = true)]
-    fn set_evm_principal(&mut self, evm: Principal) {
-        let core = self.core();
-        core.borrow().inspect_set_evm_principal();
-        core.borrow_mut().config.set_evm_principal(evm);
-
-        info!("Bridge canister EVM principal changed to {evm}");
-    }
-
     /// Returns bridge contract address for EVM.
     /// If contract isn't initialized yet - returns None.
     #[query(trait = true)]
@@ -364,28 +351,6 @@ mod tests {
         inject::get_context().update_id(owner());
 
         let _ = canister_call!(canister.set_owner(Principal::anonymous()), ()).await;
-    }
-
-    #[tokio::test]
-    async fn set_evm_principal_works() {
-        let mut canister = init_canister().await;
-
-        inject::get_context().update_id(owner());
-        let _ = canister_call!(canister.set_evm_principal(bob()), ()).await;
-
-        // check if state updated
-        let stored_evm = canister_call!(canister.get_evm_principal(), Principal)
-            .await
-            .unwrap();
-        assert_eq!(stored_evm, bob());
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "Running this method is only allowed for the owner of the canister")]
-    async fn set_evm_principal_rejected_for_non_owner() {
-        let mut canister = init_canister().await;
-
-        let _ = canister_call!(canister.set_evm_principal(bob()), ()).await;
     }
 
     #[tokio::test]

--- a/src/bridge-canister/src/config.rs
+++ b/src/bridge-canister/src/config.rs
@@ -59,12 +59,6 @@ impl BridgeConfig {
         self.evm_principal
     }
 
-    /// Sets principal of EVM canister with which the minter canister works.
-    pub fn set_evm_principal(&mut self, evm: Principal) {
-        self.evm_principal = evm;
-        self.clone().store();
-    }
-
     /// Returns parameters of EVM canister with which the minter canister works.
     pub(crate) fn get_evm_params(&self) -> Option<EvmParams> {
         self.evm_params.clone()

--- a/src/bridge-canister/src/core.rs
+++ b/src/bridge-canister/src/core.rs
@@ -122,11 +122,6 @@ impl BridgeCore {
         self.inspect_caller_is_owner()
     }
 
-    /// Inspect check for `set_evm_principal` API method.
-    pub fn inspect_set_evm_principal(&self) {
-        self.inspect_caller_is_owner()
-    }
-
     /// Inspect check for `set_bft_bridge_contract` API method.
     pub fn inspect_set_bft_bridge_contract(&self) {
         self.inspect_caller_is_owner()

--- a/src/bridge-canister/src/inspect.rs
+++ b/src/bridge-canister/src/inspect.rs
@@ -15,7 +15,6 @@ pub fn bridge_inspect() {
         "set_logger_filter" => core.inspect_set_logger_filter(),
         "ic_logs" => core.inspect_ic_logs(),
         "set_owner" => core.inspect_set_owner(),
-        "set_evm_principal" => core.inspect_set_evm_principal(),
         "set_bft_bridge_contract" => core.inspect_set_bft_bridge_contract(),
         _ => {}
     }

--- a/src/bridge-client/src/bridge_client.rs
+++ b/src/bridge-client/src/bridge_client.rs
@@ -50,14 +50,6 @@ pub trait BridgeCanisterClient<C: CanisterClient> {
         self.client().query("get_evm_principal", ()).await
     }
 
-    /// Sets principal of EVM canister with which the minter canister works.
-    ///
-    /// This method should be called only by current owner,
-    /// else `Error::NotAuthorised` will be returned.
-    async fn set_evm_principal(&mut self, evm: Principal) -> CanisterClientResult<()> {
-        self.client().update("set_evm_principal", (evm,)).await
-    }
-
     /// Returns the address of the BFT bridge contract in EVM canister.
     async fn get_bft_bridge_contract(&self) -> CanisterClientResult<McResult<Option<H160>>> {
         self.client().update("get_bft_bridge_contract", ()).await


### PR DESCRIPTION
## Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-947


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
