### PR TITLE
[EPROD-929] Add token decimals to WrappedToken constructor

### DIFF
--- a/solidity/src/WrappedToken.sol
+++ b/solidity/src/WrappedToken.sol
@@ -12,11 +12,11 @@ contract WrappedToken is ERC20 {
     uint8 private _decimals;
 
     // Initializes contract with the given name and symbl
-    constructor(string memory name_, string memory symbol_, address _owner) ERC20(name_, symbol_) {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_, address _owner) ERC20(name_, symbol_) {
         owner = _owner;
         _name = name_;
         _symbol = symbol_;
-        _decimals = super.decimals();
+        _decimals = decimals_;
     }
 
     // Perform IERC20 transfer.

--- a/solidity/src/abstract/TokenManager.sol
+++ b/solidity/src/abstract/TokenManager.sol
@@ -43,12 +43,12 @@ abstract contract TokenManager is Initializable {
     }
 
     /// Creates a new ERC20 compatible token contract as a wrapper for the given `externalToken`.
-    function deployERC20(string memory name, string memory symbol, bytes32 baseTokenID) public returns (address) {
+    function deployERC20(string memory name, string memory symbol, uint8 decimals, bytes32 baseTokenID) public returns (address) {
         require(isWrappedSide, "Only for wrapped side");
         require(_baseToWrapped[baseTokenID] == address(0), "Wrapper already exist");
 
         // Create the new token
-        WrappedToken wrappedERC20 = new WrappedToken(name, symbol, address(this));
+        WrappedToken wrappedERC20 = new WrappedToken(name, symbol, decimals, address(this));
 
         _baseToWrapped[baseTokenID] = address(wrappedERC20);
         _wrappedToBase[address(wrappedERC20)] = baseTokenID;

--- a/solidity/test/contract_tests/BftBridge.t.sol
+++ b/solidity/test/contract_tests/BftBridge.t.sol
@@ -165,14 +165,24 @@ contract BftBridgeTest is Test {
 
     function testGetWrappedToken() public {
         bytes32 base_token_id = _createIdFromPrincipal(abi.encodePacked(uint8(1)));
-        address wrapped_address = _wrappedBridge.deployERC20("Token", "TKN", base_token_id);
+        address wrapped_address = _wrappedBridge.deployERC20("Token", "TKN", 18, base_token_id);
         assertEq(wrapped_address, _wrappedBridge.getWrappedToken(base_token_id));
     }
 
     function testGetBaseToken() public {
         bytes32 base_token_id = _createIdFromPrincipal(abi.encodePacked(uint8(1)));
-        address wrapped_address = _wrappedBridge.deployERC20("Token", "TKN", base_token_id);
+        address wrapped_address = _wrappedBridge.deployERC20("Token", "TKN", 18, base_token_id);
         assertEq(base_token_id, _wrappedBridge.getBaseToken(wrapped_address));
+    }
+
+    // Creates a wrapped token with custom name, symbol, and decimals
+    function testDeployERC20CustomDecimals() public {
+        bytes32 base_token_id = _createIdFromPrincipal(abi.encodePacked(uint8(1)));
+        address wrapped_address = _wrappedBridge.deployERC20("WholaLottaLove", "LEDZEP", 21, base_token_id);
+        WrappedToken token = WrappedToken(wrapped_address);
+        assertEq(token.name(), "WholaLottaLove");
+        assertEq(token.symbol(), "LEDZEP");
+        assertEq(token.decimals(), 21);
     }
 
     function testListTokenPairs() public {
@@ -184,7 +194,7 @@ contract BftBridgeTest is Test {
 
         address[3] memory wrapped_tokens;
         for (uint256 i = 0; i < 3; i++) {
-            address wrapped_address = _wrappedBridge.deployERC20("Token", "TKN", base_token_ids[i]);
+            address wrapped_address = _wrappedBridge.deployERC20("Token", "TKN", 18, base_token_ids[i]);
             wrapped_tokens[i] = wrapped_address;
         }
 
@@ -214,7 +224,7 @@ contract BftBridgeTest is Test {
     function testBurnBaseSideWithoutApproveShouldFail() public {
         bytes memory principal = abi.encodePacked(uint8(1), uint8(2), uint8(3));
 
-        WrappedToken erc20 = new WrappedToken("omar", "OMAR", _owner);
+        WrappedToken erc20 = new WrappedToken("omar", "OMAR", 18, _owner);
         address erc20Address = address(erc20);
 
         vm.prank(address(_owner));
@@ -246,7 +256,7 @@ contract BftBridgeTest is Test {
     function testBurnWrappedSideWithUnregisteredToken() public {
         bytes memory principal = abi.encodePacked(uint8(1), uint8(2), uint8(3));
 
-        address erc20 = address(new WrappedToken("omar", "OMAR", _owner));
+        address erc20 = address(new WrappedToken("omar", "OMAR", 18, _owner));
 
         bytes32 toTokenId = _createIdFromPrincipal(abi.encodePacked(uint8(1)));
         vm.expectRevert(bytes("Invalid from address; not registered in the bridge"));
@@ -256,7 +266,7 @@ contract BftBridgeTest is Test {
     function testBurnBaseSideWithUnregisteredToken() public {
         bytes memory principal = abi.encodePacked(uint8(1), uint8(2), uint8(3));
 
-        WrappedToken erc20 = new WrappedToken("omar", "OMAR", _owner);
+        WrappedToken erc20 = new WrappedToken("omar", "OMAR", 18, _owner);
         address erc20Address = address(erc20);
 
         vm.prank(address(_owner));
@@ -270,7 +280,7 @@ contract BftBridgeTest is Test {
     }
 
     function testMintBaseSideWithUnregisteredToken() public {
-        WrappedToken erc20 = new WrappedToken("omar", "OMAR", _owner);
+        WrappedToken erc20 = new WrappedToken("omar", "OMAR", 18, _owner);
         address erc20Address = address(erc20);
 
         vm.prank(address(_owner));
@@ -285,7 +295,7 @@ contract BftBridgeTest is Test {
     }
 
     function testMintWrappedSideWithUnregisteredToken() public {
-        WrappedToken erc20 = new WrappedToken("omar", "OMAR", _owner);
+        WrappedToken erc20 = new WrappedToken("omar", "OMAR", 18, _owner);
         address erc20Address = address(erc20);
 
         vm.prank(address(_owner));
@@ -448,7 +458,7 @@ contract BftBridgeTest is Test {
         order.senderID = _createIdFromPrincipal(abi.encodePacked(uint8(1), uint8(2), uint8(3)));
         order.fromTokenID = _createIdFromPrincipal(abi.encodePacked(uint8(1), uint8(2), uint8(3), uint8(4)));
         order.recipient = _alice;
-        order.toERC20 = _wrappedBridge.deployERC20("Token", "TKN", order.fromTokenID);
+        order.toERC20 = _wrappedBridge.deployERC20("Token", "TKN", 18, order.fromTokenID);
         order.nonce = 0;
         order.senderChainID = 0;
         order.recipientChainID = _CHAIN_ID;
@@ -467,7 +477,7 @@ contract BftBridgeTest is Test {
         order.senderID = _createIdFromPrincipal(abi.encodePacked(uint8(1), uint8(2), uint8(3)));
         order.fromTokenID = _createIdFromPrincipal(abi.encodePacked(uint8(1), uint8(2), uint8(3), uint8(4)));
         order.recipient = address(_owner);
-        order.toERC20 = _wrappedBridge.deployERC20("Token", "TKN", order.fromTokenID);
+        order.toERC20 = _wrappedBridge.deployERC20("Token", "TKN", 18, order.fromTokenID);
         order.nonce = 0;
         order.senderChainID = 0;
         order.recipientChainID = _CHAIN_ID;

--- a/solidity/test/contract_tests/WrappedToken.t.sol
+++ b/solidity/test/contract_tests/WrappedToken.t.sol
@@ -11,7 +11,7 @@ contract WrappedTokenTest is Test {
     WrappedToken _token;
 
     function setUp() public {
-        _token = new WrappedToken("Token", "TKN", _owner);
+        _token = new WrappedToken("Token", "TKN", 18, _owner);
     }
 
     function testTransferFromOnwer() public {
@@ -153,4 +153,12 @@ contract WrappedTokenTest is Test {
         vm.expectRevert("Unauthorised Access");
         _token.setMetaData(bytes32(bytes("New token")), bytes16(bytes("New symbol")), 42);
     }
+
+    function testConstructorMetadataSuccess() public {
+        WrappedToken token = new WrappedToken("FromAnotherSpace", "UFO", 15, _owner);
+        assertEq(token.name(), "FromAnotherSpace");
+        assertEq(token.symbol(), "UFO");
+        assertEq(token.decimals(), 15);
+    }
+
 }

--- a/src/bridge-tool/src/main.rs
+++ b/src/bridge-tool/src/main.rs
@@ -173,6 +173,10 @@ struct CreateTokenArgs {
     #[arg(long)]
     token_name: String,
 
+    /// Decimal places of the token.
+    #[arg(long, default_value = "18")]
+    token_decimals: u8,
+
     /// ID of the source token.
     ///
     /// ID can be in one of the following forms:
@@ -628,6 +632,7 @@ async fn create_token(args: CreateTokenArgs) {
     let input = BFTBridge::deployERC20Call {
         name: args.token_name.clone(),
         symbol: args.token_name,
+        decimals: args.token_decimals,
         baseTokenID: token_id.0.into(),
     }
     .abi_encode();

--- a/src/integration-tests/tests/context/mod.rs
+++ b/src/integration-tests/tests/context/mod.rs
@@ -589,6 +589,7 @@ pub trait TestContext {
         let input = BFTBridge::deployERC20Call {
             name: "Wrapper".into(),
             symbol: "WPT".into(),
+            decimals: 18,
             baseTokenID: base_token_id.0.into(),
         }
         .abi_encode();

--- a/src/rune-bridge/src/canister.rs
+++ b/src/rune-bridge/src/canister.rs
@@ -97,7 +97,6 @@ impl RuneBridge {
         self.set_timers();
     }
 
-
     /// Returns the bitcoin address that a user has to use to deposit runes to be received on the given Ethereum address.
     #[query]
     pub fn get_deposit_address(&self, eth_address: H160) -> Result<String, GetAddressError> {

--- a/src/rune-bridge/src/canister.rs
+++ b/src/rune-bridge/src/canister.rs
@@ -97,6 +97,8 @@ impl RuneBridge {
         self.set_timers();
     }
 
+
+    /// Returns the bitcoin address that a user has to use to deposit runes to be received on the given Ethereum address.
     #[query]
     pub fn get_deposit_address(&self, eth_address: H160) -> Result<String, GetAddressError> {
         crate::key::get_transit_address(&get_state(), &eth_address).map(|v| v.to_string())
@@ -188,6 +190,9 @@ impl RuneBridge {
         rune_info_amounts
     }
 
+    /// This was implemented for testing purposes.
+    /// It is not used in the production code.
+    /// To be removed. See: EPROD-935
     #[update]
     pub fn admin_configure_indexers(&self, no_of_indexer_urls: u8, indexer_urls: HashSet<String>) {
         get_state().borrow().check_admin(ic::caller());

--- a/src/rune-bridge/src/canister.rs
+++ b/src/rune-bridge/src/canister.rs
@@ -189,9 +189,6 @@ impl RuneBridge {
         rune_info_amounts
     }
 
-    /// This was implemented for testing purposes.
-    /// It is not used in the production code.
-    /// To be removed. See: EPROD-935
     #[update]
     pub fn admin_configure_indexers(&self, no_of_indexer_urls: u8, indexer_urls: HashSet<String>) {
         get_state().borrow().check_admin(ic::caller());

--- a/src/rune-bridge/src/ledger.rs
+++ b/src/rune-bridge/src/ledger.rs
@@ -18,7 +18,9 @@ use crate::memory::{LEDGER_MEMORY_ID, MEMORY_MANAGER, USED_UTXOS_REGISTRY_MEMORY
 
 /// Data structure to keep track of utxos owned by the canister.
 pub struct UtxoLedger {
+    /// contains a list of utxos on the main canister account (which get there as a change from withdrawal transactions)
     utxo_storage: StableBTreeMap<UtxoKey, UtxoDetails, VirtualMemory<DefaultMemoryImpl>>,
+    /// contains a list of utxos that are on user's deposit address.
     used_utxos_registry: StableBTreeMap<UtxoKey, UsedUtxoDetails, VirtualMemory<DefaultMemoryImpl>>,
 }
 


### PR DESCRIPTION
## Issue ticket

Issue ticket link:
https://infinityswap.atlassian.net/browse/EPROD-929

## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative
- [x] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [x] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [x] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility


### Testing 

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
