### PR TITLE
EPROD 900 withdrawal transactions are unnecessarily large

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
+dependencies = [
+ "bitcoin_hashes 0.11.0",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +810,12 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+
+[[package]]
+name = "bitcoin_hashes"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
@@ -815,6 +832,30 @@ dependencies = [
  "bitcoin-internals",
  "hex-conservative",
  "serde",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb70725a621848c83b3809913d5314c0d20ca84877d99dd909504b564edab00"
+dependencies = [
+ "bitcoincore-rpc-json",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "856ffbee2e492c23bca715d72ea34aae80d58400f2bda26a82015d6bc2ec3662"
+dependencies = [
+ "bitcoin 0.31.2",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5971,7 +6012,9 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "async-trait",
+ "bip39",
  "bitcoin 0.31.2",
+ "bitcoincore-rpc",
  "bridge-canister",
  "bridge-client",
  "bridge-did",
@@ -6010,11 +6053,15 @@ dependencies = [
  "icrc2-bridge",
  "jsonrpc-core",
  "once_cell",
+ "ord-rs",
+ "ordinals",
  "rand",
+ "reqwest 0.12.5",
  "rune-bridge",
  "serde",
  "serde_bytes",
  "serde_json",
+ "serial_test",
  "signature-verification-canister-client",
  "thiserror",
  "tokio",
@@ -6103,6 +6150,17 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
+]
+
+[[package]]
+name = "jsonrpc"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6841,8 +6899,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ord-rs"
-version = "0.1.5"
-source = "git+https://github.com/bitfinity-network/ord-rs?tag=v0.1.5#dde7e4176521539e5e96d4cf1d16ffc9f02dfff5"
+version = "0.1.7"
+source = "git+https://github.com/bitfinity-network/ord-rs?tag=v0.1.7#37ee134ea9ce70ebdc87ca2a9e75d543371aef19"
 dependencies = [
  "async-trait",
  "bitcoin 0.31.2",
@@ -6859,9 +6917,9 @@ dependencies = [
 
 [[package]]
 name = "ordinals"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69dc8f090e996b63e1f96972f0d619f497c9545464c7bddf65e42d38576b3f3"
+checksum = "fb572a6faac38e826e5a6e8a143d6104d47ce75757a93dfd31912a0b91cada8d"
 dependencies = [
  "bitcoin 0.30.2",
  "derive_more",
@@ -8179,6 +8237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478f373151538826ed50feaceeef7095ad435065a48153af789005fd5e44c0d"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8243,6 +8310,12 @@ dependencies = [
  "ring 0.17.8",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0495e4577c672de8254beb68d01a9b62d0e8a13c099edecdbedccce3223cd29f"
 
 [[package]]
 name = "sec1"
@@ -8503,6 +8576,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
 dependencies = [
  "darling 0.20.9",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -9573,9 +9671,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ mockall = "0.12"
 num-bigint = "0.4"
 num-traits = "0.2"
 once_cell = "1.16"
-ord-rs = { git = "https://github.com/bitfinity-network/ord-rs", tag = "v0.1.6" }
+ord-rs = { git = "https://github.com/bitfinity-network/ord-rs", tag = "v0.1.7" }
 ordinals = "0.0.9"
 rand = { version = "0.8", features = ["std_rng", "small_rng"] }
 reqwest = { version = "0.12", default-features = false }

--- a/scripts/tests/dfx_tests.sh
+++ b/scripts/tests/dfx_tests.sh
@@ -105,16 +105,14 @@ dfx ledger fabricate-cycles --t 1000000 --canister $wallet_principal
 sleep 10
 
 # run tests
-set +e
 cargo test -p integration-tests --features dfx_tests $@
 TEST_RESULT=$?
-set -e
 
 killall -9 icx-proxy || true
 
 dfx stop
 
-if [ "$DOCKER" -gt 0 ] && [ "$TEST_RESULT" -eq 0 ]; then
+if [ "$DOCKER" -gt 0 ]; then
     stop_docker
 fi
 

--- a/scripts/tests/dfx_tests.sh
+++ b/scripts/tests/dfx_tests.sh
@@ -105,7 +105,10 @@ dfx ledger fabricate-cycles --t 1000000 --canister $wallet_principal
 sleep 10
 
 # run tests
+set +e
 cargo test -p integration-tests --features dfx_tests $@
+TEST_RESULT=$?
+set -e
 
 killall -9 icx-proxy || true
 
@@ -115,4 +118,4 @@ if [ "$DOCKER" -gt 0 ] && [ "$TEST_RESULT" -eq 0 ]; then
     stop_docker
 fi
 
-exit 0
+exit $TEST_RESULT

--- a/src/rune-bridge/src/core/deposit.rs
+++ b/src/rune-bridge/src/core/deposit.rs
@@ -18,7 +18,8 @@ use crate::canister::get_rune_state;
 use crate::core::index_provider::{OrdIndexProvider, RuneIndexProvider};
 use crate::core::utxo_provider::{IcUtxoProvider, UtxoProvider};
 use crate::interface::DepositError;
-use crate::key::BtcSignerType;
+use crate::key::{get_derivation_path_ic, BtcSignerType};
+use crate::ledger::UnspentUtxoInfo;
 use crate::ops::RuneBridgeOp;
 use crate::rune_info::{RuneInfo, RuneName};
 use crate::state::RuneState;
@@ -371,14 +372,38 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> RuneDeposit<UTXO, INDEX> {
     }
 
     fn filter_out_used_utxos(&self, get_utxos_response: &mut GetUtxosResponse) {
-        let (_, existing) = self.rune_state.borrow().ledger().load_unspent_utxos();
+        let existing = self.rune_state.borrow().ledger().load_unspent_utxos();
 
         get_utxos_response.utxos.retain(|utxo| {
-            !existing.iter().any(|v| {
-                v.outpoint.txid.as_byte_array()[..] == utxo.outpoint.txid
-                    && v.outpoint.vout == utxo.outpoint.vout
-            })
+            !existing
+                .values()
+                .any(|v| Self::check_already_used_utxo(v, utxo))
         })
+    }
+
+    /// Deposit UTXO to the ledger.
+    pub async fn deposit(
+        &self,
+        utxo: &Utxo,
+        dst_address: &H160,
+        rune_info: Vec<RuneInfo>,
+    ) -> Result<(), DepositError> {
+        let address = self.get_transit_address(dst_address).await;
+        let derivation_path = get_derivation_path_ic(dst_address);
+        let mut state = self.rune_state.borrow_mut();
+        let ledger = state.ledger_mut();
+        let existing = ledger.load_unspent_utxos();
+
+        if existing
+            .values()
+            .any(|v| Self::check_already_used_utxo(v, utxo))
+        {
+            return Err(DepositError::UtxoAlreadyUsed);
+        }
+
+        ledger.deposit(utxo.clone(), &address, derivation_path, rune_info);
+
+        Ok(())
     }
 
     pub async fn mark_used_utxo(
@@ -389,17 +414,22 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> RuneDeposit<UTXO, INDEX> {
         let address = self.get_transit_address(dst_address).await;
         let mut state = self.rune_state.borrow_mut();
         let ledger = state.ledger_mut();
-        let (_, existing) = ledger.load_unspent_utxos();
+        let existing = ledger.load_unspent_utxos();
 
-        if existing.iter().any(|v| {
-            v.outpoint.txid.as_byte_array()[..] == utxo.outpoint.txid
-                && v.outpoint.vout == utxo.outpoint.vout
-        }) {
+        if existing
+            .values()
+            .any(|v| Self::check_already_used_utxo(v, utxo))
+        {
             return Err(DepositError::UtxoAlreadyUsed);
         }
 
         ledger.mark_as_used((&utxo.outpoint).into(), address.clone());
         Ok(())
+    }
+
+    fn check_already_used_utxo(v: &UnspentUtxoInfo, utxo: &Utxo) -> bool {
+        v.tx_input_info.outpoint.txid.as_byte_array()[..] == utxo.outpoint.txid
+            && v.tx_input_info.outpoint.vout == utxo.outpoint.vout
     }
 
     pub async fn get_mint_amounts(

--- a/src/rune-bridge/src/core/deposit.rs
+++ b/src/rune-bridge/src/core/deposit.rs
@@ -406,27 +406,6 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> RuneDeposit<UTXO, INDEX> {
         Ok(())
     }
 
-    pub async fn mark_used_utxo(
-        &self,
-        utxo: &Utxo,
-        dst_address: &H160,
-    ) -> Result<(), DepositError> {
-        let address = self.get_transit_address(dst_address).await;
-        let mut state = self.rune_state.borrow_mut();
-        let ledger = state.ledger_mut();
-        let existing = ledger.load_unspent_utxos();
-
-        if existing
-            .values()
-            .any(|v| Self::check_already_used_utxo(v, utxo))
-        {
-            return Err(DepositError::UtxoAlreadyUsed);
-        }
-
-        ledger.mark_as_used((&utxo.outpoint).into(), address.clone());
-        Ok(())
-    }
-
     fn check_already_used_utxo(v: &UnspentUtxoInfo, utxo: &Utxo) -> bool {
         v.tx_input_info.outpoint.txid.as_byte_array()[..] == utxo.outpoint.txid
             && v.tx_input_info.outpoint.vout == utxo.outpoint.vout

--- a/src/rune-bridge/src/core/withdrawal.rs
+++ b/src/rune-bridge/src/core/withdrawal.rs
@@ -12,6 +12,7 @@ use candid::{CandidType, Deserialize};
 use did::H160;
 use ic_exports::ic_cdk::api::management_canister::bitcoin::{Outpoint, Utxo};
 use ic_exports::ic_kit::ic;
+use ord_rs::fees::{estimate_edict_transaction_fees, EstimateEdictTxFeesArgs};
 use ord_rs::wallet::{CreateEdictTxArgs, ScriptType, TxInputInfo};
 use ord_rs::OrdTransactionBuilder;
 use ordinals::RuneId;
@@ -191,14 +192,60 @@ impl<UTXO: UtxoProvider> Withdrawal<UTXO> {
             ..
         } = payload;
 
-        let (_, mut utxos) = self.state.borrow().ledger().load_unspent_utxos();
+        let fee_rate = self.get_fee_rate().await?;
+
+        let unspent_utxo_info = self.state.borrow().ledger().load_unspent_utxos();
         let funding_address = self.get_transit_address(&sender).await;
-        let mut funding_utxos: Vec<_> = self
+        let rune_change_address = self.get_change_address().await;
+
+        // get rune utxos
+        let mut input_utxos: Vec<_> = unspent_utxo_info
+            .into_values()
+            .filter(|info| info.rune_info.contains(&rune_info))
+            .map(|info| info.tx_input_info)
+            .collect();
+
+        // if there are no utxos, return an error
+        if input_utxos.is_empty() {
+            return Err(WithdrawError::NoInputs);
+        }
+
+        // get funding utxos, but filter out input utxos
+        let funding_utxos = self
             .utxo_provider
             .get_utxos(&funding_address)
             .await
-            .map_err(|_e| WithdrawError::NoInputs)?
+            .map_err(|_| WithdrawError::NoInputs)?
             .utxos
+            .into_iter()
+            .filter(|utxo| {
+                input_utxos.iter().all(|input| {
+                    input.outpoint.txid != Txid::from_slice(&utxo.outpoint.txid).unwrap()
+                        && input.outpoint.vout != utxo.outpoint.vout
+                })
+            })
+            .collect();
+
+        let Ok(dst_address) = Address::from_str(&dst_address) else {
+            return Err(WithdrawError::InvalidRequest(format!(
+                "Failed to decode recipient address from string: {dst_address}"
+            )));
+        };
+        let dst_address = dst_address.assume_checked();
+
+        // Get the utxos that can fund the transaction with the minimum number of utxos
+        let funding_utxos: Vec<_> = self
+            .get_greedy_funding_utxos(GetGreedyFundingUtxosArgs {
+                rune_utxos_count: input_utxos.len(),
+                funding_utxos,
+                rune_change_address: rune_change_address.clone(),
+                destination_address: dst_address.clone(),
+                change_address: funding_address.clone(),
+                rune: rune_info.id(),
+                rune_amount: amount,
+                fee_rate,
+            })
+            .ok_or(WithdrawError::InsufficientFunds)?
             .into_iter()
             .map(|utxo| TxInputInfo {
                 outpoint: OutPoint {
@@ -213,29 +260,27 @@ impl<UTXO: UtxoProvider> Withdrawal<UTXO> {
             })
             .collect();
 
-        utxos.append(&mut funding_utxos);
-
-        let Ok(dst_address) = Address::from_str(&dst_address) else {
-            return Err(WithdrawError::InvalidRequest(format!(
-                "Failed to decode recipient address from string: {dst_address}"
-            )));
-        };
+        input_utxos.extend(funding_utxos);
+        log::info!("input_utxos utxos: {}", input_utxos.len());
+        log::debug!("input_utxos: {input_utxos:?}");
 
         let tx = self
-            .build_withdraw_transaction(
+            .build_withdraw_transaction(WithdrawalTransactionArgs {
                 amount,
-                dst_address.clone().assume_checked(),
-                funding_address,
-                rune_info.id(),
-                utxos.clone(),
-            )
+                dst_address: dst_address.clone(),
+                change_address: funding_address,
+                rune: rune_info.id(),
+                inputs: input_utxos.clone(),
+                fee_rate,
+                rune_change_address,
+            })
             .await?;
 
         {
             let mut state = self.state.borrow_mut();
             let ledger = state.ledger_mut();
-            for utxo in utxos {
-                ledger.mark_as_used(utxo.outpoint.into(), dst_address.clone().assume_checked());
+            for utxo in input_utxos {
+                ledger.mark_as_used(utxo.outpoint.into(), dst_address.clone());
             }
         }
 
@@ -265,9 +310,10 @@ impl<UTXO: UtxoProvider> Withdrawal<UTXO> {
         };
 
         self.state.borrow_mut().ledger_mut().deposit(
-            &[change_utxo],
+            change_utxo,
             &change_address,
             self.get_change_derivation_path(),
+            vec![],
         );
 
         Ok(())
@@ -279,15 +325,12 @@ impl<UTXO: UtxoProvider> Withdrawal<UTXO> {
             .await
     }
 
-    pub async fn build_withdraw_transaction(
+    /// Build a withdrawal transaction.
+    async fn build_withdraw_transaction(
         &self,
-        amount: u128,
-        dst_address: Address,
-        change_address: Address,
-        rune: RuneId,
-        inputs: Vec<TxInputInfo>,
+        args: WithdrawalTransactionArgs,
     ) -> Result<Transaction, WithdrawError> {
-        if inputs.is_empty() {
+        if args.inputs.is_empty() {
             return Err(WithdrawError::NoInputs);
         }
 
@@ -296,17 +339,14 @@ impl<UTXO: UtxoProvider> Withdrawal<UTXO> {
 
         let builder = OrdTransactionBuilder::new(public_key, ScriptType::P2WSH, wallet);
 
-        let rune_change_address = self.get_change_address().await;
-        let fee_rate = self.get_fee_rate().await?;
-
         let args = CreateEdictTxArgs {
-            rune,
-            inputs,
-            destination: dst_address,
-            change_address,
-            rune_change_address,
-            amount,
-            fee_rate,
+            rune: args.rune,
+            inputs: args.inputs,
+            destination: args.dst_address,
+            change_address: args.change_address,
+            rune_change_address: args.rune_change_address,
+            amount: args.amount,
+            fee_rate: args.fee_rate,
         };
         let unsigned_tx = builder.create_edict_transaction(&args).map_err(|err| {
             log::warn!("Failed to create withdraw transaction: {err:?}");
@@ -351,6 +391,68 @@ impl<UTXO: UtxoProvider> Withdrawal<UTXO> {
             Ok(current_fee_rate)
         }
     }
+
+    /// Get the minimum amount of utxos that must be used to fund the transaction.
+    ///
+    /// Returns the utxos that can fund the transaction with the minimum number of utxos.
+    /// If the transaction cannot be funded with the minimum number of utxos, the function will return None.
+    fn get_greedy_funding_utxos(&self, mut args: GetGreedyFundingUtxosArgs) -> Option<Vec<Utxo>> {
+        let mut utxos_count = 1;
+        // sort the utxos by value; descending
+        args.funding_utxos.sort_by(|a, b| b.value.cmp(&a.value));
+
+        // try to fund the transaction with the minimum number of utxos
+        while utxos_count <= args.funding_utxos.len() {
+            let required_fee = estimate_edict_transaction_fees(EstimateEdictTxFeesArgs {
+                script_type: ScriptType::P2WSH,
+                number_of_inputs: utxos_count + args.rune_utxos_count,
+                current_fee_rate: args.fee_rate,
+                multisig_config: None,
+                rune_change_address: args.rune_change_address.clone(),
+                destination_address: args.destination_address.clone(),
+                change_address: args.change_address.clone(),
+                rune: args.rune,
+                rune_amount: args.rune_amount,
+            });
+
+            // find the minimum number of utxos that can fund the transaction
+            let solution = &args.funding_utxos[0..utxos_count];
+            let solution_value =
+                Amount::from_sat(solution.iter().map(|utxo| utxo.value).sum::<u64>());
+            if solution_value >= required_fee {
+                log::debug!("Found a funding solution with {utxos_count} utxos; required fee {required_fee}; fee funds: {solution_value}");
+                return Some(solution.to_vec());
+            }
+
+            // otherwise try with more utxos
+            utxos_count += 1;
+        }
+
+        None
+    }
+}
+
+/// Arguments for the `get_greedy_funding_utxos` function.
+struct GetGreedyFundingUtxosArgs {
+    rune_utxos_count: usize,
+    funding_utxos: Vec<Utxo>,
+    rune_change_address: Address,
+    destination_address: Address,
+    change_address: Address,
+    rune: RuneId,
+    rune_amount: u128,
+    fee_rate: FeeRate,
+}
+
+/// Arguments for the `build_withdraw_transaction` function.
+struct WithdrawalTransactionArgs {
+    amount: u128,
+    dst_address: Address,
+    change_address: Address,
+    rune: RuneId,
+    inputs: Vec<TxInputInfo>,
+    fee_rate: FeeRate,
+    rune_change_address: Address,
 }
 
 #[cfg(test)]
@@ -369,18 +471,8 @@ mod test {
     #[tokio::test]
     async fn test_should_get_fee_rate() {
         MockContext::new().inject();
-        let state = RuneState::default();
-        let fake_utxo_provider = FakeUtxoProvider {
-            fee_rate: FeeRate::from_sat_per_vb(1).unwrap(),
-        };
-        let mut withdrawal = Withdrawal {
-            state: Rc::new(RefCell::new(state)),
-            utxo_provider: fake_utxo_provider,
-            signer: BtcSignerType::Local(LocalSigner::new(PrivateKey::generate(
-                bitcoin::Network::Regtest,
-            ))),
-            network: bitcoin::Network::Regtest,
-        };
+
+        let mut withdrawal = test_withdrawal();
 
         // First call should return the fee rate from the provider
         let fee_rate = withdrawal.get_fee_rate().await.unwrap();
@@ -411,6 +503,165 @@ mod test {
 
         async fn send_tx(&self, _transaction: &Transaction) -> Result<(), WithdrawError> {
             unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_should_get_greedy_funding_utxos() {
+        let rune = RuneId::new(219, 1).unwrap();
+        let rune_amount = 9500;
+
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
+        let address =
+            Address::from_str("bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k")
+                .unwrap()
+                .assume_checked();
+        // let's calculate the required fee for a transaction with 2 funding utxos
+        let args = EstimateEdictTxFeesArgs {
+            script_type: ScriptType::P2WSH,
+            number_of_inputs: 2 + 2,
+            current_fee_rate: fee_rate,
+            multisig_config: None,
+            rune_change_address: address.clone(),
+            destination_address: address.clone(),
+            change_address: address.clone(),
+            rune,
+            rune_amount,
+        };
+
+        let fee = estimate_edict_transaction_fees(args);
+
+        let first_utxo_value = (fee.to_sat() * 6).div_ceil(10); // 60% of the fee
+        let second_utxo_value = (fee.to_sat() * 4).div_ceil(10); // 40% of the fee
+
+        // let's create funding utxos
+        let funding_utxos = vec![
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![0; 32],
+                    vout: 0,
+                },
+                value: first_utxo_value,
+                height: 0,
+            },
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![1; 32],
+                    vout: 0,
+                },
+                value: second_utxo_value,
+                height: 0,
+            },
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![2; 32],
+                    vout: 0,
+                },
+                value: 10,
+                height: 0,
+            },
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![3; 32],
+                    vout: 0,
+                },
+                value: 10,
+                height: 0,
+            },
+        ];
+
+        let greedy_funding_utxos = test_withdrawal()
+            .get_greedy_funding_utxos(GetGreedyFundingUtxosArgs {
+                rune_utxos_count: 2,
+                funding_utxos,
+                rune_change_address: address.clone(),
+                destination_address: address.clone(),
+                change_address: address.clone(),
+                rune,
+                rune_amount,
+                fee_rate,
+            })
+            .unwrap();
+
+        assert_eq!(greedy_funding_utxos.len(), 2);
+        assert_eq!(greedy_funding_utxos[0].value, first_utxo_value);
+        assert_eq!(greedy_funding_utxos[1].value, second_utxo_value);
+    }
+
+    #[test]
+    fn test_return_none_in_case_not_enough_funds() {
+        let rune = RuneId::new(219, 1).unwrap();
+        let rune_amount = 9500;
+
+        let fee_rate = FeeRate::from_sat_per_vb(1).unwrap();
+        let address =
+            Address::from_str("bc1pxwww0ct9ue7e8tdnlmug5m2tamfn7q06sahstg39ys4c9f3340qqxrdu9k")
+                .unwrap()
+                .assume_checked();
+
+        // let's create funding utxos
+        let funding_utxos = vec![
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![0; 32],
+                    vout: 0,
+                },
+                value: 10,
+                height: 0,
+            },
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![1; 32],
+                    vout: 0,
+                },
+                value: 40,
+                height: 0,
+            },
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![2; 32],
+                    vout: 0,
+                },
+                value: 50,
+                height: 0,
+            },
+            Utxo {
+                outpoint: Outpoint {
+                    txid: vec![3; 32],
+                    vout: 0,
+                },
+                value: 12,
+                height: 0,
+            },
+        ];
+
+        let greedy_funding_utxos =
+            test_withdrawal().get_greedy_funding_utxos(GetGreedyFundingUtxosArgs {
+                rune_utxos_count: 2,
+                funding_utxos,
+                rune_change_address: address.clone(),
+                destination_address: address.clone(),
+                change_address: address.clone(),
+                rune,
+                rune_amount,
+                fee_rate,
+            });
+
+        assert!(greedy_funding_utxos.is_none());
+    }
+
+    fn test_withdrawal() -> Withdrawal<FakeUtxoProvider> {
+        let state = RuneState::default();
+        let fake_utxo_provider = FakeUtxoProvider {
+            fee_rate: FeeRate::from_sat_per_vb(1).unwrap(),
+        };
+        Withdrawal {
+            state: Rc::new(RefCell::new(state)),
+            utxo_provider: fake_utxo_provider,
+            signer: BtcSignerType::Local(LocalSigner::new(PrivateKey::generate(
+                bitcoin::Network::Regtest,
+            ))),
+            network: bitcoin::Network::Regtest,
         }
     }
 }

--- a/src/rune-bridge/src/interface.rs
+++ b/src/rune-bridge/src/interface.rs
@@ -101,6 +101,7 @@ pub enum WithdrawError {
     TransactionSending,
     FeeRateRequest,
     ChangeAddress,
+    InsufficientFunds,
     InvalidRequest(String),
     InternalError(String),
 }

--- a/src/rune-bridge/src/ledger.rs
+++ b/src/rune-bridge/src/ledger.rs
@@ -622,14 +622,16 @@ mod tests {
             .remove_unspent_utxo(&UtxoKey::from(&utxos[0].outpoint));
 
         // check
-        let keys = state
+        let mut keys = state
             .borrow()
             .ledger()
             .load_unspent_utxos()
             .keys()
             .cloned()
             .collect::<Vec<_>>();
+        keys.sort();
         assert_eq!(keys.len(), 2);
+
         assert_eq!(keys[0].tx_id.to_vec(), utxos[0].outpoint.txid);
         assert_eq!(keys[0].vout, utxos[0].outpoint.vout);
         assert_eq!(keys[1].tx_id.to_vec(), utxos[1].outpoint.txid);

--- a/src/rune-bridge/src/ledger.rs
+++ b/src/rune-bridge/src/ledger.rs
@@ -77,8 +77,7 @@ impl UtxoLedger {
 
         // Add rune info if it is present
         if !rune_info.is_empty() {
-            self.rune_info_by_utxo
-                .insert(utxo_key, UtxoRunes(rune_info));
+            self.rune_info_by_utxo.insert(utxo_key, rune_info.into());
         }
 
         log::debug!(
@@ -112,7 +111,7 @@ impl UtxoLedger {
                         rune_info: self
                             .rune_info_by_utxo
                             .get(&key)
-                            .map(|rune_info| rune_info.0.clone())
+                            .map(|rune_info| rune_info.runes().to_vec())
                             .unwrap_or_default(),
                     },
                 )

--- a/src/rune-bridge/src/ledger.rs
+++ b/src/rune-bridge/src/ledger.rs
@@ -1,53 +1,27 @@
-use std::borrow::Cow;
+mod used_utxo_details;
+mod utxo_details;
+mod utxo_key;
+mod utxo_runes;
+
 use std::collections::HashMap;
-use std::fmt;
-use std::mem::size_of;
-use std::str::FromStr;
 
 use bitcoin::hashes::sha256d::Hash;
-use bitcoin::{Address, Amount, Network, OutPoint, TxOut, Txid};
-use candid::{CandidType, Decode, Encode};
-use ic_exports::ic_cdk::api::management_canister::bitcoin::{Outpoint, Utxo};
+use bitcoin::{Address, Amount, OutPoint, TxOut, Txid};
+use ic_exports::ic_cdk::api::management_canister::bitcoin::Utxo;
 use ic_exports::ic_kit::ic;
 use ic_stable_structures::stable_structures::DefaultMemoryImpl;
-use ic_stable_structures::{BTreeMapStructure, Bound, StableBTreeMap, Storable, VirtualMemory};
+use ic_stable_structures::{BTreeMapStructure, StableBTreeMap, VirtualMemory};
 use ord_rs::wallet::TxInputInfo;
-use serde::Deserialize;
 
-use crate::key::{ic_dp_to_derivation_path, IcBtcSigner};
+use self::used_utxo_details::UsedUtxoDetails;
+use self::utxo_details::UtxoDetails;
+pub use self::utxo_key::UtxoKey;
+use self::utxo_runes::UtxoRunes;
+use crate::key::ic_dp_to_derivation_path;
 use crate::memory::{
     LEDGER_MEMORY_ID, MEMORY_MANAGER, RUNE_INFO_BY_UTXO_MEMORY_ID, USED_UTXOS_REGISTRY_MEMORY_ID,
 };
 use crate::rune_info::RuneInfo;
-
-/// Data structure to keep track rune information for a utxo.
-struct UtxoRunes(Vec<RuneInfo>);
-
-impl Storable for UtxoRunes {
-    const BOUND: Bound = Bound::Unbounded;
-
-    fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        let list_len = u64::from_be_bytes(bytes[0..8].try_into().unwrap()) as usize;
-        let mut runes = Vec::with_capacity(list_len);
-
-        for rune_buf in bytes[8..bytes.len()].chunks(RuneInfo::BOUND.max_size() as usize) {
-            runes.push(RuneInfo::from_bytes(Cow::Borrowed(rune_buf)));
-        }
-
-        Self(runes)
-    }
-
-    fn to_bytes(&self) -> Cow<[u8]> {
-        let mut bytes = Vec::with_capacity(8 + self.0.len() * RuneInfo::BOUND.max_size() as usize);
-        bytes.extend_from_slice(&(self.0.len() as u64).to_be_bytes());
-
-        for rune in &self.0 {
-            bytes.extend_from_slice(&rune.to_bytes());
-        }
-
-        Cow::Owned(bytes)
-    }
-}
 
 /// Data structure to keep track of utxos owned by the canister.
 pub struct UtxoLedger {
@@ -70,113 +44,6 @@ impl Default for UtxoLedger {
             ),
         }
     }
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, CandidType, Deserialize, Hash)]
-pub struct UtxoKey {
-    pub tx_id: [u8; 32],
-    pub vout: u32,
-}
-
-impl fmt::Display for UtxoKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", hex::encode(self.tx_id), self.vout)
-    }
-}
-
-impl Storable for UtxoKey {
-    fn to_bytes(&self) -> Cow<[u8]> {
-        let bytes = Encode!(self).expect("cannot serialize utxo key");
-        Cow::Owned(bytes)
-    }
-
-    fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        Decode!(&bytes, Self).expect("cannot deserialize utxo key")
-    }
-
-    const BOUND: Bound = Bound::Bounded {
-        max_size: 60,
-        is_fixed_size: true,
-    };
-}
-
-impl From<OutPoint> for UtxoKey {
-    fn from(value: OutPoint) -> Self {
-        Self {
-            tx_id: *<Hash as AsRef<[u8; 32]>>::as_ref(&value.txid.to_raw_hash()),
-            vout: value.vout,
-        }
-    }
-}
-
-impl From<&Outpoint> for UtxoKey {
-    fn from(value: &Outpoint) -> Self {
-        Self {
-            tx_id: value.txid.clone().try_into().expect("invalid tx id"),
-            vout: value.vout,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
-pub struct UtxoDetails {
-    value: u64,
-    script_buf: Vec<u8>,
-    derivation_path: Vec<Vec<u8>>,
-}
-
-impl UtxoDetails {
-    const MAX_SCRIPT_SIZE: u32 = 128;
-    const DERIVATION_PATH_SIZE: u32 = IcBtcSigner::DERIVATION_PATH_SIZE;
-}
-
-impl Storable for UtxoDetails {
-    fn to_bytes(&self) -> Cow<[u8]> {
-        let bytes = Encode!(self).expect("failed to serialize utxo");
-        Cow::Owned(bytes)
-    }
-
-    fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        Decode!(&bytes, Self).expect("failed to deserialize utxo")
-    }
-
-    const BOUND: Bound = Bound::Bounded {
-        max_size: size_of::<u64>() as u32 + Self::MAX_SCRIPT_SIZE + Self::DERIVATION_PATH_SIZE,
-        is_fixed_size: false,
-    };
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
-pub struct UsedUtxoDetails {
-    pub used_at: u64,
-    owner_address: String,
-}
-
-impl UsedUtxoDetails {
-    const MAX_BITCOIN_ADDRESS_SIZE: u32 = 96;
-
-    /// Returns the owner address of the utxo.
-    pub fn owner_address(&self, network: Network) -> Result<Address, Box<dyn std::error::Error>> {
-        Address::from_str(self.owner_address.as_str())?
-            .require_network(network)
-            .map_err(|e| e.into())
-    }
-}
-
-impl Storable for UsedUtxoDetails {
-    fn to_bytes(&self) -> Cow<[u8]> {
-        let bytes = Encode!(self).expect("failed to serialize utxo");
-        Cow::Owned(bytes)
-    }
-
-    fn from_bytes(bytes: Cow<[u8]>) -> Self {
-        Decode!(&bytes, Self).expect("failed to deserialize utxo")
-    }
-
-    const BOUND: Bound = Bound::Bounded {
-        max_size: size_of::<u64>() as u32 + Self::MAX_BITCOIN_ADDRESS_SIZE,
-        is_fixed_size: false,
-    };
 }
 
 /// Information about the unspent utxo.
@@ -291,86 +158,13 @@ impl UtxoLedger {
 mod tests {
     use std::str::FromStr;
 
-    use bitcoin::{Network, PublicKey};
-    use did::H160;
+    use ic_exports::ic_cdk::api::management_canister::bitcoin::Outpoint;
     use ic_exports::ic_kit::MockContext;
     use ordinals::Rune;
 
     use super::*;
     use crate::canister::get_rune_state;
-    use crate::key::get_derivation_path_ic;
     use crate::rune_info::RuneName;
-
-    #[test]
-    fn key_serialization() {
-        let key = UtxoKey {
-            tx_id: [123; 32],
-            vout: 544331,
-        };
-
-        let serialized = key.to_bytes();
-        let Bound::Bounded { max_size, .. } = UtxoKey::BOUND else {
-            panic!("Key is unbounded");
-        };
-
-        assert_eq!(serialized.len() as u32, max_size);
-        let deserialized = UtxoKey::from_bytes(serialized);
-        assert_eq!(deserialized, key);
-    }
-
-    #[test]
-    fn value_serialization() {
-        let address = Address::p2wpkh(
-            &PublicKey::from_str(
-                "038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354",
-            )
-            .unwrap(),
-            Network::Signet,
-        )
-        .unwrap();
-        let derivation_path = get_derivation_path_ic(
-            &H160::from_hex_str("0x0dc9f6938e9b47fd8553df50bcbdb62d67239007").unwrap(),
-        );
-        let value = UtxoDetails {
-            value: 100500,
-            script_buf: address.script_pubkey().to_bytes(),
-            derivation_path,
-        };
-
-        let serialized = value.to_bytes();
-        let Bound::Bounded { max_size, .. } = UtxoDetails::BOUND else {
-            panic!("Key is unbounded");
-        };
-
-        assert!((serialized.len() as u32) < max_size);
-        let deserialized = UtxoDetails::from_bytes(serialized);
-        assert_eq!(deserialized, value);
-    }
-
-    #[test]
-    fn test_should_serialize_used_utxo() {
-        let address = Address::p2wpkh(
-            &PublicKey::from_str(
-                "038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354",
-            )
-            .unwrap(),
-            Network::Signet,
-        )
-        .unwrap();
-        let value = UsedUtxoDetails {
-            used_at: 100500,
-            owner_address: address.to_string(),
-        };
-
-        let serialized = value.to_bytes();
-        let Bound::Bounded { max_size, .. } = UsedUtxoDetails::BOUND else {
-            panic!("Key is unbounded");
-        };
-
-        assert!((serialized.len() as u32) < max_size);
-        let deserialized = UsedUtxoDetails::from_bytes(serialized);
-        assert_eq!(deserialized, value);
-    }
 
     #[test]
     fn test_should_deposit_utxo() {

--- a/src/rune-bridge/src/ledger/used_utxo_details.rs
+++ b/src/rune-bridge/src/ledger/used_utxo_details.rs
@@ -1,0 +1,73 @@
+use std::borrow::Cow;
+use std::str::FromStr as _;
+
+use bitcoin::{Address, Network};
+use candid::{CandidType, Decode, Encode};
+use ic_stable_structures::{Bound, Storable};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
+pub struct UsedUtxoDetails {
+    pub used_at: u64,
+    pub owner_address: String,
+}
+
+impl UsedUtxoDetails {
+    const MAX_BITCOIN_ADDRESS_SIZE: u32 = 96;
+
+    /// Returns the owner address of the utxo.
+    pub fn owner_address(&self, network: Network) -> Result<Address, Box<dyn std::error::Error>> {
+        Address::from_str(self.owner_address.as_str())?
+            .require_network(network)
+            .map_err(|e| e.into())
+    }
+}
+
+impl Storable for UsedUtxoDetails {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = Encode!(self).expect("failed to serialize utxo");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(&bytes, Self).expect("failed to deserialize utxo")
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: size_of::<u64>() as u32 + Self::MAX_BITCOIN_ADDRESS_SIZE,
+        is_fixed_size: false,
+    };
+}
+
+#[cfg(test)]
+mod test {
+
+    use bitcoin::PublicKey;
+
+    use super::*;
+
+    #[test]
+    fn test_should_serialize_used_utxo() {
+        let address = Address::p2wpkh(
+            &PublicKey::from_str(
+                "038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354",
+            )
+            .unwrap(),
+            Network::Signet,
+        )
+        .unwrap();
+        let value = UsedUtxoDetails {
+            used_at: 100500,
+            owner_address: address.to_string(),
+        };
+
+        let serialized = value.to_bytes();
+        let Bound::Bounded { max_size, .. } = UsedUtxoDetails::BOUND else {
+            panic!("Key is unbounded");
+        };
+
+        assert!((serialized.len() as u32) < max_size);
+        let deserialized = UsedUtxoDetails::from_bytes(serialized);
+        assert_eq!(deserialized, value);
+    }
+}

--- a/src/rune-bridge/src/ledger/used_utxo_details.rs
+++ b/src/rune-bridge/src/ledger/used_utxo_details.rs
@@ -6,9 +6,12 @@ use candid::{CandidType, Decode, Encode};
 use ic_stable_structures::{Bound, Storable};
 use serde::Deserialize;
 
+/// Details regarding a used utxo.
 #[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
 pub struct UsedUtxoDetails {
+    /// timestamp when the utxo was used.
     pub used_at: u64,
+    /// address of the utxo owner.
     pub owner_address: String,
 }
 

--- a/src/rune-bridge/src/ledger/utxo_details.rs
+++ b/src/rune-bridge/src/ledger/utxo_details.rs
@@ -6,10 +6,14 @@ use serde::Deserialize;
 
 use crate::key::IcBtcSigner;
 
+/// Utxo details to be stored in the ledger.
 #[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
 pub struct UtxoDetails {
+    /// btc value of the utxo.
     pub value: u64,
+    /// script buffer of the utxo.
     pub script_buf: Vec<u8>,
+    /// derivation path of the utxo.
     pub derivation_path: Vec<Vec<u8>>,
 }
 

--- a/src/rune-bridge/src/ledger/utxo_details.rs
+++ b/src/rune-bridge/src/ledger/utxo_details.rs
@@ -1,0 +1,76 @@
+use std::borrow::Cow;
+
+use candid::{CandidType, Decode, Encode};
+use ic_stable_structures::{Bound, Storable};
+use serde::Deserialize;
+
+use crate::key::IcBtcSigner;
+
+#[derive(Debug, Clone, Eq, PartialEq, CandidType, Deserialize)]
+pub struct UtxoDetails {
+    pub value: u64,
+    pub script_buf: Vec<u8>,
+    pub derivation_path: Vec<Vec<u8>>,
+}
+
+impl UtxoDetails {
+    const MAX_SCRIPT_SIZE: u32 = 128;
+    const DERIVATION_PATH_SIZE: u32 = IcBtcSigner::DERIVATION_PATH_SIZE;
+}
+
+impl Storable for UtxoDetails {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = Encode!(self).expect("failed to serialize utxo");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(&bytes, Self).expect("failed to deserialize utxo")
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: size_of::<u64>() as u32 + Self::MAX_SCRIPT_SIZE + Self::DERIVATION_PATH_SIZE,
+        is_fixed_size: false,
+    };
+}
+
+#[cfg(test)]
+mod test {
+
+    use std::str::FromStr;
+
+    use bitcoin::{Address, Network, PublicKey};
+    use did::H160;
+
+    use super::*;
+    use crate::key::get_derivation_path_ic;
+
+    #[test]
+    fn test_should_serialize_and_deserialize_details() {
+        let address = Address::p2wpkh(
+            &PublicKey::from_str(
+                "038f47dcd43ba6d97fc9ed2e3bba09b175a45fac55f0683e8cf771e8ced4572354",
+            )
+            .unwrap(),
+            Network::Signet,
+        )
+        .unwrap();
+        let derivation_path = get_derivation_path_ic(
+            &H160::from_hex_str("0x0dc9f6938e9b47fd8553df50bcbdb62d67239007").unwrap(),
+        );
+        let value = UtxoDetails {
+            value: 100500,
+            script_buf: address.script_pubkey().to_bytes(),
+            derivation_path,
+        };
+
+        let serialized = value.to_bytes();
+        let Bound::Bounded { max_size, .. } = UtxoDetails::BOUND else {
+            panic!("Key is unbounded");
+        };
+
+        assert!((serialized.len() as u32) < max_size);
+        let deserialized = UtxoDetails::from_bytes(serialized);
+        assert_eq!(deserialized, value);
+    }
+}

--- a/src/rune-bridge/src/ledger/utxo_key.rs
+++ b/src/rune-bridge/src/ledger/utxo_key.rs
@@ -1,0 +1,78 @@
+use std::borrow::Cow;
+use std::fmt;
+
+use bitcoin::hashes::sha256d::Hash;
+use bitcoin::OutPoint;
+use candid::{CandidType, Decode, Encode};
+use ic_exports::ic_cdk::api::management_canister::bitcoin::Outpoint;
+use ic_stable_structures::{Bound, Storable};
+use serde::Deserialize;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, CandidType, Deserialize, Hash)]
+pub struct UtxoKey {
+    pub tx_id: [u8; 32],
+    pub vout: u32,
+}
+
+impl fmt::Display for UtxoKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", hex::encode(self.tx_id), self.vout)
+    }
+}
+
+impl Storable for UtxoKey {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = Encode!(self).expect("cannot serialize utxo key");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(&bytes, Self).expect("cannot deserialize utxo key")
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 60,
+        is_fixed_size: true,
+    };
+}
+
+impl From<OutPoint> for UtxoKey {
+    fn from(value: OutPoint) -> Self {
+        Self {
+            tx_id: *<Hash as AsRef<[u8; 32]>>::as_ref(&value.txid.to_raw_hash()),
+            vout: value.vout,
+        }
+    }
+}
+
+impl From<&Outpoint> for UtxoKey {
+    fn from(value: &Outpoint) -> Self {
+        Self {
+            tx_id: value.txid.clone().try_into().expect("invalid tx id"),
+            vout: value.vout,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_should_encode_and_decode_key() {
+        let key = UtxoKey {
+            tx_id: [123; 32],
+            vout: 544331,
+        };
+
+        let serialized = key.to_bytes();
+        let Bound::Bounded { max_size, .. } = UtxoKey::BOUND else {
+            panic!("Key is unbounded");
+        };
+
+        assert_eq!(serialized.len() as u32, max_size);
+        let deserialized = UtxoKey::from_bytes(serialized);
+        assert_eq!(deserialized, key);
+    }
+}

--- a/src/rune-bridge/src/ledger/utxo_key.rs
+++ b/src/rune-bridge/src/ledger/utxo_key.rs
@@ -8,9 +8,12 @@ use ic_exports::ic_cdk::api::management_canister::bitcoin::Outpoint;
 use ic_stable_structures::{Bound, Storable};
 use serde::Deserialize;
 
+/// Unique identifier for a utxo.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, CandidType, Deserialize, Hash)]
 pub struct UtxoKey {
+    /// Transaction id of the utxo.
     pub tx_id: [u8; 32],
+    /// Vout of the utxo. (Index of the output in the transaction)
     pub vout: u32,
 }
 

--- a/src/rune-bridge/src/ledger/utxo_runes.rs
+++ b/src/rune-bridge/src/ledger/utxo_runes.rs
@@ -5,7 +5,20 @@ use ic_stable_structures::{Bound, Storable};
 use crate::rune_info::RuneInfo;
 
 /// Data structure to keep track rune information for a utxo.
-pub struct UtxoRunes(pub Vec<RuneInfo>);
+pub struct UtxoRunes(Vec<RuneInfo>);
+
+impl UtxoRunes {
+    /// Returns the list of rune information.
+    pub fn runes(&self) -> &[RuneInfo] {
+        &self.0
+    }
+}
+
+impl From<Vec<RuneInfo>> for UtxoRunes {
+    fn from(runes: Vec<RuneInfo>) -> Self {
+        Self(runes)
+    }
+}
 
 impl Storable for UtxoRunes {
     const BOUND: Bound = Bound::Unbounded;

--- a/src/rune-bridge/src/ledger/utxo_runes.rs
+++ b/src/rune-bridge/src/ledger/utxo_runes.rs
@@ -1,0 +1,67 @@
+use std::borrow::Cow;
+
+use ic_stable_structures::{Bound, Storable};
+
+use crate::rune_info::RuneInfo;
+
+/// Data structure to keep track rune information for a utxo.
+pub struct UtxoRunes(pub Vec<RuneInfo>);
+
+impl Storable for UtxoRunes {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let list_len = u64::from_be_bytes(bytes[0..8].try_into().unwrap()) as usize;
+        let mut runes = Vec::with_capacity(list_len);
+
+        for rune_buf in bytes[8..bytes.len()].chunks(RuneInfo::BOUND.max_size() as usize) {
+            runes.push(RuneInfo::from_bytes(Cow::Borrowed(rune_buf)));
+        }
+
+        Self(runes)
+    }
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = Vec::with_capacity(8 + self.0.len() * RuneInfo::BOUND.max_size() as usize);
+        bytes.extend_from_slice(&(self.0.len() as u64).to_be_bytes());
+
+        for rune in &self.0 {
+            bytes.extend_from_slice(&rune.to_bytes());
+        }
+
+        Cow::Owned(bytes)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use ordinals::Rune;
+
+    use super::*;
+    use crate::rune_info::RuneName;
+
+    #[test]
+    fn test_should_encode_and_decode_utxo_runes() {
+        let rune_info = vec![
+            RuneInfo {
+                name: RuneName::from(Rune(0xdeadbeef)),
+                decimals: 18,
+                block: 0x1234567890abcdef,
+                tx: 0x12345678,
+            },
+            RuneInfo {
+                name: RuneName::from(Rune(0xcafebabe)),
+                decimals: 18,
+                block: 0x1234567890abcdef,
+                tx: 0x12345678,
+            },
+        ];
+
+        let utxo_runes = UtxoRunes(rune_info.clone());
+        let bytes = utxo_runes.to_bytes();
+        let decoded = UtxoRunes::from_bytes(Cow::Borrowed(&bytes));
+
+        assert_eq!(utxo_runes.0, decoded.0);
+    }
+}

--- a/src/rune-bridge/src/memory.rs
+++ b/src/rune-bridge/src/memory.rs
@@ -8,10 +8,11 @@ pub const LOGGER_SETTINGS_MEMORY_ID: MemoryId = MemoryId::new(13);
 pub const BURN_REQUEST_MEMORY_ID: MemoryId = MemoryId::new(14);
 pub const LEDGER_MEMORY_ID: MemoryId = MemoryId::new(15);
 pub const USED_UTXOS_REGISTRY_MEMORY_ID: MemoryId = MemoryId::new(16);
-pub const OPERATIONS_MEMORY_ID: MemoryId = MemoryId::new(17);
-pub const OPERATIONS_LOG_MEMORY_ID: MemoryId = MemoryId::new(18);
-pub const OPERATIONS_MAP_MEMORY_ID: MemoryId = MemoryId::new(19);
-pub const OPERATIONS_COUNTER_MEMORY_ID: MemoryId = MemoryId::new(20);
+pub const RUNE_INFO_BY_UTXO_MEMORY_ID: MemoryId = MemoryId::new(17);
+pub const OPERATIONS_MEMORY_ID: MemoryId = MemoryId::new(18);
+pub const OPERATIONS_LOG_MEMORY_ID: MemoryId = MemoryId::new(19);
+pub const OPERATIONS_MAP_MEMORY_ID: MemoryId = MemoryId::new(20);
+pub const OPERATIONS_COUNTER_MEMORY_ID: MemoryId = MemoryId::new(21);
 
 thread_local! {
     pub static MEMORY_MANAGER: IcMemoryManager<DefaultMemoryImpl> = IcMemoryManager::init(DefaultMemoryImpl::default());

--- a/src/rune-bridge/src/ops.rs
+++ b/src/rune-bridge/src/ops.rs
@@ -332,8 +332,9 @@ impl RuneBridgeOp {
             .await
             .map_err(|err| Error::FailedToProgress(format!("inputs are not confirmed: {err:?}")))?;
 
+        let deposit_runes = runes_to_wrap.iter().map(|rune| rune.rune_info).collect();
         deposit
-            .mark_used_utxo(&utxo, &dst_address)
+            .deposit(&utxo, &dst_address, deposit_runes)
             .await
             .map_err(|err| Error::FailedToProgress(format!("{err:?}")))?;
 


### PR DESCRIPTION
Use a greedy selector for utxos to use only those necessary to pay the withdraw tx.

Also don't use select utxos with the rune to pay the fee, for this purpose we need to map utxo to runes in the ledger.

Previously we didn't select the rune utxo in the withdraw tx, since we included all the utxos.

## Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-900


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
