### PR TITLE
[EPROD-961] Add a way to reschedule stuck bridge operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
  "ic-canister-client",
  "ic-exports",
  "ic-log",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "ic-storage",
  "ic-task-scheduler",
  "jsonrpc-core",
@@ -966,7 +966,7 @@ dependencies = [
  "ic-canister-client",
  "ic-exports",
  "ic-log",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "ic-storage",
  "ic-task-scheduler",
  "icrc2-bridge",
@@ -994,7 +994,7 @@ dependencies = [
  "ic-canister-client",
  "ic-exports",
  "ic-log",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "ordinals",
  "rand",
  "serde",
@@ -1044,7 +1044,7 @@ dependencies = [
  "ic-canister-client",
  "ic-exports",
  "ic-log",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "ic-task-scheduler",
  "jsonrpc-core",
  "log",
@@ -1081,8 +1081,8 @@ dependencies = [
  "ic-ckbtc-minter",
  "ic-exports",
  "ic-log",
- "ic-metrics 0.20.0",
- "ic-stable-structures 0.20.0",
+ "ic-metrics 0.20.1",
+ "ic-stable-structures 0.20.1",
  "ic-storage",
  "ic-task-scheduler",
  "jsonrpc-core",
@@ -1869,7 +1869,7 @@ dependencies = [
  "ethers-core",
  "hex",
  "ic-log",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "jsonrpc-core",
  "log",
  "num",
@@ -2163,8 +2163,8 @@ dependencies = [
  "ic-canister-client",
  "ic-exports",
  "ic-log",
- "ic-metrics 0.20.0",
- "ic-stable-structures 0.20.0",
+ "ic-metrics 0.20.1",
+ "ic-stable-structures 0.20.1",
  "ic-storage",
  "ic-task-scheduler",
  "jsonrpc-core",
@@ -2209,7 +2209,7 @@ dependencies = [
  "hex",
  "ic-canister",
  "ic-exports",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "serde",
  "sha2 0.10.8",
  "thiserror",
@@ -3273,8 +3273,8 @@ dependencies = [
 
 [[package]]
 name = "ic-canister"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "ic-canister-macros",
  "ic-exports",
@@ -3282,8 +3282,8 @@ dependencies = [
 
 [[package]]
 name = "ic-canister-client"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "async-trait",
  "candid",
@@ -3318,8 +3318,8 @@ dependencies = [
 
 [[package]]
 name = "ic-canister-macros"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -3785,8 +3785,8 @@ dependencies = [
 
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "getrandom",
 ]
@@ -4602,15 +4602,15 @@ dependencies = [
 
 [[package]]
 name = "ic-exports"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "candid",
  "flate2",
  "ic-cdk 0.15.0",
  "ic-cdk-macros 0.15.0",
  "ic-cdk-timers",
- "ic-crypto-getrandom-for-wasm 0.20.0",
+ "ic-crypto-getrandom-for-wasm 0.20.1",
  "ic-kit",
  "ic-ledger-types",
  "icrc-ledger-types 0.1.6",
@@ -4803,8 +4803,8 @@ dependencies = [
 
 [[package]]
 name = "ic-kit"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "candid",
  "futures",
@@ -4871,8 +4871,8 @@ dependencies = [
 
 [[package]]
 name = "ic-log"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4882,7 +4882,7 @@ dependencies = [
  "humantime",
  "ic-canister",
  "ic-exports",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "ic-storage",
  "log",
  "ringbuffer",
@@ -4978,8 +4978,8 @@ dependencies = [
 
 [[package]]
 name = "ic-metrics"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "candid",
  "ic-canister",
@@ -5207,8 +5207,8 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "candid",
  "ic-stable-structures 0.6.5",
@@ -5355,8 +5355,8 @@ dependencies = [
 
 [[package]]
 name = "ic-storage"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "candid",
  "ic-exports",
@@ -5367,8 +5367,8 @@ dependencies = [
 
 [[package]]
 name = "ic-storage-derive"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "quote",
  "syn 2.0.74",
@@ -5424,14 +5424,14 @@ dependencies = [
 
 [[package]]
 name = "ic-task-scheduler"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "bincode",
  "candid",
  "ic-cdk-timers",
  "ic-kit",
- "ic-stable-structures 0.20.0",
+ "ic-stable-structures 0.20.1",
  "log",
  "parking_lot",
  "serde",
@@ -5577,8 +5577,8 @@ dependencies = [
 
 [[package]]
 name = "ic-test-utils"
-version = "0.20.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#800c882277f3d13f01f8e817962c453c394d6dfa"
+version = "0.20.1"
+source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.20.x#fadfe78ff97d8ebbc926a97309bdc6ba5e961d19"
 dependencies = [
  "candid",
  "dirs",
@@ -5970,8 +5970,8 @@ dependencies = [
  "ic-canister",
  "ic-exports",
  "ic-log",
- "ic-metrics 0.20.0",
- "ic-stable-structures 0.20.0",
+ "ic-metrics 0.20.1",
+ "ic-stable-structures 0.20.1",
  "ic-storage",
  "ic-task-scheduler",
  "icrc-client",
@@ -6111,8 +6111,8 @@ dependencies = [
  "ic-icrc1-ledger",
  "ic-log",
  "ic-management-canister-types",
- "ic-metrics 0.20.0",
- "ic-stable-structures 0.20.0",
+ "ic-metrics 0.20.1",
+ "ic-stable-structures 0.20.1",
  "ic-state-machine-tests",
  "ic-test-utils",
  "ic-utils 0.37.0",
@@ -6132,6 +6132,7 @@ dependencies = [
  "signature-verification-canister-client",
  "thiserror",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7578,8 +7579,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -7599,7 +7600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.74",
@@ -8059,8 +8060,8 @@ dependencies = [
  "ic-canister-client",
  "ic-exports",
  "ic-log",
- "ic-metrics 0.20.0",
- "ic-stable-structures 0.20.0",
+ "ic-metrics 0.20.1",
+ "ic-stable-structures 0.20.1",
  "ic-storage",
  "ic-task-scheduler",
  "jsonrpc-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ signature-verification-canister-client = { git = "https://github.com/bitfinity-n
 tempfile = "3"
 thiserror = "1.0"
 tokio = { version = "1.36", features = ["macros", "rt"] }
+tokio-util = "0.7"
 vergen = { version = "8.3", default-features = false, features = [
     "build",
     "cargo",

--- a/src/bridge-utils/src/bft_events.rs
+++ b/src/bridge-utils/src/bft_events.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter};
+
 use alloy_sol_types::private::{Bytes, LogData};
 use alloy_sol_types::{SolCall, SolEvent};
 use anyhow::anyhow;
@@ -208,8 +210,36 @@ impl From<MintTokenEvent> for MintedEventData {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, CandidType, Serialize, Deserialize)]
+#[repr(u32)]
+pub enum MinterNotificationType {
+    DepositRequest = 1,
+    RescheduleOperation = 2,
+    Other,
+}
+
+impl From<u32> for MinterNotificationType {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Self::DepositRequest,
+            2 => Self::RescheduleOperation,
+            _ => Self::Other,
+        }
+    }
+}
+
+impl Display for MinterNotificationType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MinterNotificationType::DepositRequest => write!(f, "DepositRequest"),
+            MinterNotificationType::RescheduleOperation => write!(f, "RescheduleOperation"),
+            MinterNotificationType::Other => write!(f, "Other"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, CandidType, Serialize, Deserialize)]
 pub struct NotifyMinterEventData {
-    pub notification_type: u32,
+    pub notification_type: MinterNotificationType,
     pub tx_sender: did::H160,
     pub user_data: Vec<u8>,
 }
@@ -217,7 +247,7 @@ pub struct NotifyMinterEventData {
 impl From<NotifyMinterEvent> for NotifyMinterEventData {
     fn from(event: NotifyMinterEvent) -> Self {
         Self {
-            notification_type: event.notificationType,
+            notification_type: event.notificationType.into(),
             tx_sender: event.txSender.into(),
             user_data: event.userData.0.into(),
         }

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -73,6 +73,7 @@ ic-utils = { workspace = true }
 ic-metrics = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "process"] }
+tokio-util = { workspace = true }
 erc20-bridge = { path = "../erc20-bridge" }
 signature-verification-canister-client = { workspace = true }
 rune-bridge = { path = "../rune-bridge" }

--- a/src/integration-tests/tests/context/mod.rs
+++ b/src/integration-tests/tests/context/mod.rs
@@ -44,6 +44,8 @@ pub const DEFAULT_GAS_PRICE: u128 = EIP1559_INITIAL_BASE_FEE * 2;
 use alloy_sol_types::{SolCall, SolConstructor};
 use bridge_client::{Erc20BridgeClient, Icrc2BridgeClient, RuneBridgeClient};
 use bridge_did::init::BridgeInitData;
+use bridge_did::op_id::OperationId;
+use bridge_utils::bft_events::MinterNotificationType;
 use ic_log::did::LogCanisterSettings;
 
 #[async_trait::async_trait]
@@ -650,8 +652,29 @@ pub trait TestContext {
         let encoded_reason = Encode!(&reason).unwrap();
 
         let input = BFTBridge::notifyMinterCall {
-            notificationType: Default::default(),
+            notificationType: MinterNotificationType::DepositRequest as u32,
             userData: encoded_reason.into(),
+        }
+        .abi_encode();
+
+        let _receipt = self
+            .call_contract(wallet, bridge, input, 0)
+            .await
+            .map(|(_, receipt)| receipt)?;
+
+        Ok(())
+    }
+
+    async fn reschedule_operation(
+        &self,
+        operation_id: OperationId,
+        wallet: &Wallet<'_, SigningKey>,
+        bridge: &H160,
+    ) -> Result<()> {
+        let encoded_op_id = Encode!(&operation_id).unwrap();
+        let input = BFTBridge::notifyMinterCall {
+            notificationType: MinterNotificationType::RescheduleOperation as u32,
+            userData: encoded_op_id.into(),
         }
         .abi_encode();
 

--- a/src/integration-tests/tests/dfx_tests/runes.rs
+++ b/src/integration-tests/tests/dfx_tests/runes.rs
@@ -8,6 +8,7 @@ use bitcoin::{Address, Amount, PrivateKey, Txid};
 use bridge_client::BridgeCanisterClient;
 use bridge_did::id256::Id256;
 use bridge_did::op_id::OperationId;
+use bridge_utils::bft_events::MinterNotificationType;
 use bridge_utils::BFTBridge;
 use candid::{Encode, Principal};
 use did::constant::EIP1559_INITIAL_BASE_FEE;
@@ -22,7 +23,7 @@ use ic_log::did::LogCanisterSettings;
 use ord_rs::Utxo;
 use ordinals::{Etching, Rune, RuneId, Terms};
 use rune_bridge::interface::{DepositError, GetAddressError};
-use rune_bridge::ops::{RuneBridgeOp, RuneDepositRequestData, RuneMinterNotification};
+use rune_bridge::ops::{RuneBridgeOp, RuneDepositRequestData};
 use rune_bridge::rune_info::{RuneInfo, RuneName};
 use rune_bridge::state::RuneBridgeConfig;
 use tokio::time::Instant;
@@ -286,7 +287,7 @@ impl RunesContext {
         };
 
         let input = BFTBridge::notifyMinterCall {
-            notificationType: RuneMinterNotification::DEPOSIT_TYPE,
+            notificationType: MinterNotificationType::DepositRequest as u32,
             userData: Encode!(&data).unwrap().into(),
         }
         .abi_encode();

--- a/src/integration-tests/tests/pocket_ic_integration_test/mod.rs
+++ b/src/integration-tests/tests/pocket_ic_integration_test/mod.rs
@@ -34,6 +34,7 @@ sol! {
     "../../solidity/out/TestWTM.sol/WatermelonToken.json"
 }
 
+#[derive(Clone)]
 pub struct PocketIcTestContext {
     pub client: Arc<PocketIc>,
     pub canisters: TestCanisters,


### PR DESCRIPTION
## Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-961


## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative
- [x] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [x] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [x] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility


### Testing 

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
