### PR TITLE
EPROD-988 save rune state in stable storage; init args for rune bridge and other improvements

### DIFF
--- a/src/bridge-deployer/src/commands/mod.rs
+++ b/src/bridge-deployer/src/commands/mod.rs
@@ -47,12 +47,7 @@ pub enum Commands {
 
 #[derive(Subcommand, Clone, Serialize, Deserialize, Debug)]
 pub enum Bridge {
-    Rune {
-        /// The configuration to use
-        #[command(flatten)]
-        config: config::RuneBridgeConfig,
-    },
-    Icrc {
+    Btc {
         /// The configuration to use
         #[command(flatten)]
         config: config::InitBridgeConfig,
@@ -65,10 +60,18 @@ pub enum Bridge {
         #[command(name = "erc", flatten)]
         erc: config::BaseEvmSettingsConfig,
     },
-    Btc {
+    Icrc {
         /// The configuration to use
         #[command(flatten)]
         config: config::InitBridgeConfig,
+    },
+    Rune {
+        /// Bridge configuration
+        #[command(flatten)]
+        init: config::InitBridgeConfig,
+        /// Rune bridge configuration
+        #[command(flatten, name = "rune")]
+        rune: config::RuneBridgeConfig,
     },
 }
 
@@ -76,11 +79,13 @@ impl Bridge {
     /// Initialize the raw argument for the bridge
     pub fn init_raw_arg(&self) -> anyhow::Result<Vec<u8>> {
         let arg = match &self {
-            Bridge::Rune { config } => {
+            Bridge::Rune { init, rune } => {
                 trace!("Preparing Rune bridge configuration");
-                let config = rune_bridge::state::RuneBridgeConfig::from(config.clone());
-                debug!("Rune Bridge Config : {:?}", config);
-                Encode!(&config)?
+                let init_data = bridge_did::init::BridgeInitData::from(init.clone());
+                debug!("Init Bridge Config : {:?}", init_data);
+                let rune_config = rune_bridge::state::RuneBridgeConfig::from(rune.clone());
+                debug!("Rune Bridge Config : {:?}", rune_config);
+                Encode!(&init_data, &rune_config)?
             }
             Bridge::Icrc { config } => {
                 trace!("Preparing ICRC bridge configuration");

--- a/src/bridge-deployer/src/config/rune.rs
+++ b/src/bridge-deployer/src/config/rune.rs
@@ -1,34 +1,23 @@
 use std::time::Duration;
 
-use candid::Principal;
 use clap::{Parser, ValueEnum};
 use ic_exports::ic_cdk::api::management_canister::bitcoin;
-use icrc2_bridge::SigningStrategy;
 use serde::{Deserialize, Serialize};
 
-use super::{LogCanisterSettings, SigningKeyId};
+use super::LogCanisterSettings;
 
 #[derive(Parser, Debug, Serialize, Deserialize, Clone)]
 pub struct RuneBridgeConfig {
     /// The network to use for the Bitcoin blockchain
     #[arg(long)]
     pub bitcoin_network: BitcoinNetwork,
-    /// The principal of the EVM canister that is being deployed
-    #[arg(long)]
-    pub evm_principal: Principal,
-    /// The signing key ID to use for signing messages
-    #[arg(long, default_value_t = SigningKeyId::Test)]
-    pub signing_key_id: SigningKeyId,
-    /// Admin of the bridge canister
-    #[arg(long)]
-    pub admin: Principal,
     /// The minimum number of confirmations required for a Bitcoin transaction
     /// to be considered final
     #[arg(long)]
     pub min_confirmations: u32,
-    /// The number of indexers to use for the Bitcoin blockchain
+    /// The threshold for the number of indexers required to reach consensus
     #[arg(long)]
-    pub no_of_indexers: u8,
+    pub indexer_consensus_threshold: u8,
     /// The URLs of the indexers to use for the Bitcoin blockchain
     ///
     /// Note: The number of URLs must match the number of indexers specified above
@@ -66,33 +55,11 @@ impl From<RuneBridgeConfig> for rune_bridge::state::RuneBridgeConfig {
     fn from(value: RuneBridgeConfig) -> Self {
         Self {
             network: value.bitcoin_network.into(),
-            evm_principal: value.evm_principal,
-            signing_strategy: SigningStrategy::ManagementCanister {
-                key_id: value.signing_key_id.into(),
-            },
-            admin: value.admin,
-            log_settings: value
-                .log_settings
-                .map(|v| ic_log::did::LogCanisterSettings {
-                    enable_console: v.enable_console,
-                    in_memory_records: v.in_memory_records,
-                    max_record_length: v.max_record_length,
-                    log_filter: v.log_filter,
-                    acl: v.acl.map(|v| {
-                        v.iter()
-                            .map(|(principal, perm)| {
-                                (*principal, ic_log::did::LoggerPermission::from(*perm))
-                            })
-                            .collect()
-                    }),
-                })
-                .unwrap_or_default(),
             min_confirmations: value.min_confirmations,
-            no_of_indexers: value.no_of_indexers,
             indexer_urls: value.indexer_urls.into_iter().collect(),
             deposit_fee: value.deposit_fee,
             mempool_timeout: Duration::from_secs(value.mempool_timeout),
-            indexer_consensus_threshold: value.no_of_indexers,
+            indexer_consensus_threshold: value.indexer_consensus_threshold,
         }
     }
 }

--- a/src/btc-bridge/src/memory.rs
+++ b/src/btc-bridge/src/memory.rs
@@ -1,9 +1,8 @@
-use ic_stable_structures::stable_structures::DefaultMemoryImpl;
-use ic_stable_structures::{IcMemoryManager, MemoryId};
+//! Memory IDs for the BTC Bridge program.
+//!
+//! DO NOT USE MEMORY IDS BELOW 10, as they are reserved for sdk use.
 
-pub const BTC_CONFIG_MEMORY_ID: MemoryId = MemoryId::new(0);
-pub const WRAPPED_TOKEN_CONFIG_MEMORY_ID: MemoryId = MemoryId::new(1);
+use ic_stable_structures::MemoryId;
 
-thread_local! {
-    pub static MEMORY_MANAGER: IcMemoryManager<DefaultMemoryImpl> = IcMemoryManager::init(DefaultMemoryImpl::default());
-}
+pub const BTC_CONFIG_MEMORY_ID: MemoryId = MemoryId::new(10);
+pub const WRAPPED_TOKEN_CONFIG_MEMORY_ID: MemoryId = MemoryId::new(11);

--- a/src/integration-tests/tests/state_machine_tests/rune.rs
+++ b/src/integration-tests/tests/state_machine_tests/rune.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
+use bridge_did::init::BridgeInitData;
 use candid::Principal;
 use did::H160;
 use eth_signer::sign_strategy::{SigningKeyId, SigningStrategy};
@@ -39,16 +40,17 @@ impl RunesSetup {
         .unwrap();
 
         let bridge = (&context).create_canister().await.unwrap();
-        let init_args = RuneBridgeConfig {
-            network: BitcoinNetwork::Mainnet,
+        let init_args = BridgeInitData {
             evm_principal: bob(),
             signing_strategy: SigningStrategy::ManagementCanister {
                 key_id: SigningKeyId::Custom(KEY_ID.to_string()),
             },
-            admin: (&context).admin(),
+            owner: (&context).admin(),
             log_settings: Default::default(),
+        };
+        let rune_config = RuneBridgeConfig {
+            network: BitcoinNetwork::Mainnet,
             min_confirmations: 1,
-            no_of_indexers: 1,
             indexer_urls: HashSet::from_iter(["https://indexer".to_string()]),
             deposit_fee: 0,
             mempool_timeout: Duration::from_secs(60),
@@ -58,7 +60,7 @@ impl RunesSetup {
             .install_canister(
                 bridge,
                 get_rune_bridge_canister_bytecode().await,
-                (init_args,),
+                (init_args, rune_config),
             )
             .await
             .unwrap();

--- a/src/rune-bridge/src/canister.rs
+++ b/src/rune-bridge/src/canister.rs
@@ -1,12 +1,11 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
-use std::str::FromStr;
 
-use bitcoin::Address;
 use bridge_canister::runtime::state::config::ConfigStorage;
 use bridge_canister::runtime::{BridgeRuntime, RuntimeState};
 use bridge_canister::BridgeCanister;
+use bridge_did::init::BridgeInitData;
 use bridge_did::op_id::OperationId;
 use bridge_did::operation_log::{Memo, OperationLog};
 use bridge_utils::common::Pagination;
@@ -22,10 +21,8 @@ use ic_metrics::{Metrics, MetricsStorage};
 use ic_storage::IcStorage;
 
 use crate::canister::inspect::{inspect_configure_ecdsa, inspect_configure_indexers};
-use crate::core::deposit::RuneDeposit;
 use crate::interface::GetAddressError;
 use crate::ops::RuneBridgeOp;
-use crate::rune_info::RuneInfo;
 use crate::state::{RuneBridgeConfig, RuneState};
 
 mod inspect;
@@ -46,10 +43,9 @@ impl BridgeCanister for RuneBridge {
 
 impl RuneBridge {
     #[init]
-    pub fn init(&mut self, config: RuneBridgeConfig) {
-        let bridge_init_data = config.bridge_init_data();
-        get_rune_state().borrow_mut().configure(config);
+    pub fn init(&mut self, bridge_init_data: BridgeInitData, rune_bridge_config: RuneBridgeConfig) {
         self.init_bridge(bridge_init_data, Self::run_scheduler);
+        get_rune_state().borrow_mut().configure(rune_bridge_config);
     }
 
     #[post_upgrade]
@@ -65,7 +61,9 @@ impl RuneBridge {
     /// Returns the bitcoin address that a user has to use to deposit runes to be received on the given Ethereum address.
     #[query]
     pub fn get_deposit_address(&self, eth_address: H160) -> Result<String, GetAddressError> {
-        crate::key::get_transit_address(&get_rune_state(), &eth_address).map(|v| v.to_string())
+        crate::key::get_transit_address(&get_rune_state(), &eth_address)
+            .map(|v| v.to_string())
+            .map_err(GetAddressError::from)
     }
 
     #[query]
@@ -118,45 +116,35 @@ impl RuneBridge {
     pub async fn admin_configure_ecdsa(&self) {
         inspect_configure_ecdsa(self.config());
 
-        let key_id = get_rune_state().borrow().ecdsa_key_id();
+        let signing_strategy = get_runtime_state()
+            .borrow()
+            .config
+            .borrow()
+            .get_signing_strategy();
 
-        let master_key = ecdsa_public_key(EcdsaPublicKeyArgument {
+        let key_id = get_rune_state().borrow().ecdsa_key_id(&signing_strategy);
+
+        let (master_key,) = ecdsa_public_key(EcdsaPublicKeyArgument {
             canister_id: None,
             derivation_path: vec![],
-            key_id,
+            key_id: key_id.clone(),
         })
         .await
         .expect("failed to get master key");
 
-        get_rune_state().borrow_mut().configure_ecdsa(master_key.0);
+        get_rune_state()
+            .borrow_mut()
+            .configure_ecdsa(master_key, key_id)
+            .expect("failed to configure ecdsa");
     }
 
     #[update]
-    pub async fn get_rune_balances(&self, btc_address: String) -> Vec<(RuneInfo, u128)> {
-        let address = Address::from_str(&btc_address)
-            .expect("invalid address")
-            .assume_checked();
-
-        let deposit = RuneDeposit::get(get_runtime_state());
-        let utxos = deposit
-            .get_deposit_utxos(&address)
-            .await
-            .expect("failed to get utxos");
-        let (rune_info_amounts, _) = deposit
-            .get_mint_amounts(&utxos.utxos, &None)
-            .await
-            .expect("failed to get rune amounts");
-
-        rune_info_amounts
-    }
-
-    #[update]
-    pub fn admin_configure_indexers(&self, no_of_indexer_urls: u8, indexer_urls: HashSet<String>) {
+    pub fn admin_configure_indexers(&self, indexer_urls: HashSet<String>) {
         inspect_configure_indexers(self.config());
 
         get_rune_state()
             .borrow_mut()
-            .configure_indexers(no_of_indexer_urls, indexer_urls);
+            .configure_indexers(indexer_urls);
     }
 
     #[update]

--- a/src/rune-bridge/src/core/deposit.rs
+++ b/src/rune-bridge/src/core/deposit.rs
@@ -14,13 +14,13 @@ use ic_exports::ic_cdk::api::management_canister::bitcoin::{GetUtxosResponse, Ut
 use serde::Serialize;
 
 use super::index_provider::IcHttpClient;
-use crate::canister::get_rune_state;
+use crate::canister::{get_rune_state, get_runtime_state};
 use crate::core::index_provider::{OrdIndexProvider, RuneIndexProvider};
 use crate::core::rune_inputs::{GetInputsError, RuneInput, RuneInputProvider, RuneInputs};
 use crate::core::utxo_handler::{RuneToWrap, UtxoHandler, UtxoHandlerError};
 use crate::core::utxo_provider::{IcUtxoProvider, UtxoProvider};
 use crate::interface::DepositError;
-use crate::key::{get_derivation_path_ic, BtcSignerType};
+use crate::key::{get_derivation_path_ic, BtcSignerType, KeyError};
 use crate::ledger::UnspentUtxoInfo;
 use crate::ops::RuneBridgeOp;
 use crate::rune_info::{RuneInfo, RuneName};
@@ -125,18 +125,29 @@ pub(crate) struct RuneDeposit<
 }
 
 impl RuneDeposit<IcUtxoProvider, OrdIndexProvider<IcHttpClient>> {
-    pub fn new(state: Rc<RefCell<RuneState>>, runtime_state: RuntimeState<RuneBridgeOp>) -> Self {
+    pub fn new(
+        state: Rc<RefCell<RuneState>>,
+        runtime_state: RuntimeState<RuneBridgeOp>,
+    ) -> Result<Self, DepositError> {
         let state_ref = state.borrow();
+
+        let signer_strategy = get_runtime_state()
+            .borrow()
+            .config
+            .borrow()
+            .get_signing_strategy();
 
         let network = state_ref.network();
         let ic_network = state_ref.ic_btc_network();
         let indexer_urls = state_ref.indexer_urls();
-        let signer = state_ref.btc_signer();
+        let signer = state_ref
+            .btc_signer(&signer_strategy)
+            .ok_or(DepositError::SignerNotInitialized)?;
         let consensus_threshold = state_ref.indexer_consensus_threshold();
 
         drop(state_ref);
 
-        Self {
+        Ok(Self {
             rune_state: state,
             runtime_state,
             network,
@@ -147,17 +158,17 @@ impl RuneDeposit<IcUtxoProvider, OrdIndexProvider<IcHttpClient>> {
                 indexer_urls,
                 consensus_threshold,
             ),
-        }
+        })
     }
 
-    pub fn get(runtime_state: RuntimeState<RuneBridgeOp>) -> Self {
+    pub fn get(runtime_state: RuntimeState<RuneBridgeOp>) -> Result<Self, DepositError> {
         Self::new(get_rune_state(), runtime_state)
     }
 }
 
 impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> RuneInputProvider for RuneDeposit<UTXO, INDEX> {
     async fn get_inputs(&self, dst_address: &H160) -> Result<RuneInputs, GetInputsError> {
-        let transit_address = self.get_transit_address(dst_address).await;
+        let transit_address = self.get_transit_address(dst_address).await?;
         let utxos = self.get_deposit_utxos(&transit_address).await?.utxos;
         let mut inputs = RuneInputs::default();
         for utxo in utxos {
@@ -190,7 +201,7 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> UtxoHandler for RuneDeposit<U
         dst_address: &H160,
         utxo: &Utxo,
     ) -> Result<(), UtxoHandlerError> {
-        let transit_address = self.get_transit_address(dst_address).await;
+        let transit_address = self.get_transit_address(dst_address).await?;
         let utxo_response = self
             .get_deposit_utxos(&transit_address)
             .await
@@ -221,13 +232,13 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> UtxoHandler for RuneDeposit<U
         dst_address: &H160,
         utxo_runes: Vec<RuneToWrap>,
     ) -> Result<Vec<MintOrder>, UtxoHandlerError> {
-        let address = self.get_transit_address(dst_address).await;
+        let address = self.get_transit_address(dst_address).await?;
         let derivation_path = get_derivation_path_ic(dst_address);
 
         {
             let mut state = self.rune_state.borrow_mut();
             let ledger = state.ledger_mut();
-            let existing = ledger.load_unspent_utxos();
+            let existing = ledger.load_unspent_utxos()?;
 
             if existing
                 .values()
@@ -269,7 +280,7 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> RuneDeposit<UTXO, INDEX> {
             utxo_response.utxos
         );
 
-        self.filter_out_used_utxos(&mut utxo_response);
+        self.filter_out_used_utxos(&mut utxo_response)?;
 
         log::trace!(
             "Utxos at address {transit_address} after filtering out used utxos: {:?}",
@@ -279,7 +290,7 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> RuneDeposit<UTXO, INDEX> {
         Ok(utxo_response)
     }
 
-    async fn get_transit_address(&self, eth_address: &H160) -> Address {
+    async fn get_transit_address(&self, eth_address: &H160) -> Result<Address, KeyError> {
         self.signer
             .get_transit_address(eth_address, self.network)
             .await
@@ -390,66 +401,23 @@ impl<UTXO: UtxoProvider, INDEX: RuneIndexProvider> RuneDeposit<UTXO, INDEX> {
         Ok(signed_mint_order)
     }
 
-    fn filter_out_used_utxos(&self, get_utxos_response: &mut GetUtxosResponse) {
-        let existing = self.rune_state.borrow().ledger().load_unspent_utxos();
+    fn filter_out_used_utxos(
+        &self,
+        get_utxos_response: &mut GetUtxosResponse,
+    ) -> Result<(), KeyError> {
+        let existing = self.rune_state.borrow().ledger().load_unspent_utxos()?;
 
         get_utxos_response.utxos.retain(|utxo| {
             !existing
                 .values()
                 .any(|v| Self::check_already_used_utxo(v, utxo))
-        })
+        });
+
+        Ok(())
     }
 
     fn check_already_used_utxo(v: &UnspentUtxoInfo, utxo: &Utxo) -> bool {
         v.tx_input_info.outpoint.txid.as_byte_array()[..] == utxo.outpoint.txid
             && v.tx_input_info.outpoint.vout == utxo.outpoint.vout
-    }
-
-    pub async fn get_mint_amounts(
-        &self,
-        utxos: &[Utxo],
-        requested_amounts: &Option<HashMap<RuneName, u128>>,
-    ) -> Result<(Vec<(RuneInfo, u128)>, Vec<Utxo>), DepositError> {
-        let mut rune_amounts = HashMap::new();
-        let mut used_utxos = vec![];
-
-        for utxo in utxos {
-            log::info!("Get rune amounts for: {:?}", utxo);
-            let tx_rune_amounts = match self.index_provider.get_rune_amounts(utxo).await {
-                Ok(v) => v,
-                Err(err) => {
-                    log::error!("Failed to get rune amounts for utxo: {err:?}");
-                    continue;
-                }
-            };
-
-            if !tx_rune_amounts.is_empty() {
-                used_utxos.push(utxo.clone());
-                for (rune_name, amount) in tx_rune_amounts {
-                    *rune_amounts.entry(rune_name).or_default() += amount;
-                }
-            }
-        }
-
-        if rune_amounts.is_empty() {
-            return Err(DepositError::NoRunesToDeposit);
-        }
-
-        if let Some(requested) = requested_amounts {
-            if rune_amounts != *requested {
-                return Err(DepositError::InvalidAmounts {
-                    requested: requested.clone(),
-                    actual: rune_amounts,
-                });
-            }
-        }
-
-        let Some(rune_info_amounts) = self.get_rune_infos(&rune_amounts).await else {
-            return Err(DepositError::Unavailable(
-                "Ord indexer is in invalid state".to_string(),
-            ));
-        };
-
-        Ok((rune_info_amounts, used_utxos))
     }
 }

--- a/src/rune-bridge/src/core/rune_inputs.rs
+++ b/src/rune-bridge/src/core/rune_inputs.rs
@@ -5,6 +5,7 @@ use ic_exports::ic_cdk::api::management_canister::bitcoin::Utxo;
 use ic_exports::ic_kit::RejectionCode;
 use thiserror::Error;
 
+use crate::key::KeyError;
 use crate::rune_info::{RuneInfo, RuneName};
 
 #[derive(Debug, Clone, Default)]
@@ -39,6 +40,8 @@ impl RuneInputs {
 pub(crate) enum GetInputsError {
     #[error("failed to connect to IC BTC adapter: {0}")]
     BtcAdapter(String),
+    #[error("key error {0}")]
+    KeyError(#[from] KeyError),
     #[error("rune indexers returned different result for same request: {indexer_responses:?}")]
     IndexersDisagree {
         indexer_responses: Vec<(String, String)>,

--- a/src/rune-bridge/src/core/utxo_handler.rs
+++ b/src/rune-bridge/src/core/utxo_handler.rs
@@ -5,10 +5,13 @@ use ic_exports::ic_cdk::api::management_canister::bitcoin::Utxo;
 use serde::Serialize;
 use thiserror::Error;
 
+use crate::key::KeyError;
 use crate::rune_info::RuneInfo;
 
 #[derive(Debug, Clone, PartialEq, Error)]
 pub(crate) enum UtxoHandlerError {
+    #[error("key error {0}")]
+    KeyError(#[from] KeyError),
     #[error("failed to connect to IC BTC adapter: {0}")]
     BtcAdapter(String),
     #[error("requested utxo is not in the main branch")]

--- a/src/rune-bridge/src/interface.rs
+++ b/src/rune-bridge/src/interface.rs
@@ -7,6 +7,7 @@ use ordinals::Pile;
 use serde::Deserialize;
 
 use crate::core::deposit::RuneDepositPayload;
+use crate::key::KeyError;
 use crate::rune_info::RuneName;
 
 #[derive(Debug, Clone, CandidType, Deserialize, PartialEq, Eq)]
@@ -55,9 +56,15 @@ pub enum Erc20MintError {
     NothingToMint,
 }
 
-#[derive(Debug, Clone, Copy, CandidType, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, CandidType, Deserialize, PartialEq, Eq)]
 pub enum GetAddressError {
-    Derivation,
+    Key(String),
+}
+
+impl From<KeyError> for GetAddressError {
+    fn from(e: KeyError) -> Self {
+        GetAddressError::Key(e.to_string())
+    }
 }
 
 #[derive(Debug, Clone, CandidType, Deserialize)]
@@ -74,6 +81,8 @@ pub enum DepositError {
     UtxosNotConfirmed,
     NoDstTokenAddress,
     UtxoAlreadyUsed,
+    SignerNotInitialized,
+    KeyError(String),
     InvalidAmounts {
         requested: HashMap<RuneName, u128>,
         actual: HashMap<RuneName, u128>,
@@ -92,8 +101,15 @@ pub enum DepositError {
     Evm(String),
 }
 
+impl From<KeyError> for DepositError {
+    fn from(e: KeyError) -> Self {
+        DepositError::KeyError(e.to_string())
+    }
+}
+
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub enum WithdrawError {
+    SignerNotInitialized,
     NoInputs,
     TransactionCreation,
     TransactionSigning,
@@ -104,6 +120,13 @@ pub enum WithdrawError {
     InsufficientFunds,
     InvalidRequest(String),
     InternalError(String),
+    KeyError(String),
+}
+
+impl From<KeyError> for WithdrawError {
+    fn from(e: KeyError) -> Self {
+        WithdrawError::KeyError(e.to_string())
+    }
 }
 
 #[derive(Debug, Copy, Clone, CandidType, Deserialize, Hash, PartialEq, Eq)]

--- a/src/rune-bridge/src/key.rs
+++ b/src/rune-bridge/src/key.rs
@@ -1,17 +1,36 @@
 use std::cell::RefCell;
 
 use async_trait::async_trait;
-use bitcoin::bip32::{ChildNumber, DerivationPath, Xpub};
+use bitcoin::address::Error as BitcoinAddressError;
+use bitcoin::bip32::{ChildNumber, DerivationPath, Error as Bip32Error, Xpub};
 use bitcoin::secp256k1::ecdsa::Signature;
-use bitcoin::secp256k1::{Error, Message, Secp256k1};
+use bitcoin::secp256k1::{Error as Secp256Error, Message, Secp256k1};
 use bitcoin::{Address, Network, PublicKey};
 use did::H160;
 use ic_exports::ic_cdk::api::management_canister::ecdsa::{sign_with_ecdsa, SignWithEcdsaArgument};
 use ord_rs::wallet::LocalSigner;
 use ord_rs::BtcTxSigner;
+use thiserror::Error;
 
-use crate::interface::GetAddressError;
 use crate::state::{MasterKey, RuneState};
+
+/// Key result type
+pub type KeyResult<T> = Result<T, KeyError>;
+
+/// Key and signer error types
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum KeyError {
+    #[error("bip32 error: {0}")]
+    Bip32(#[from] Bip32Error),
+    #[error("failed to derive address: {0}")]
+    BitcoinAddress(#[from] BitcoinAddressError),
+    #[error("invalid derivation path")]
+    InvalidDerivationPath,
+    #[error("secp256 error: {0}")]
+    Secp256(#[from] Secp256Error),
+    #[error("signer not initialized")]
+    SignerNotInitialized,
+}
 
 pub const DERIVATION_PATH_PREFIX: u8 = 7;
 
@@ -54,7 +73,7 @@ impl BtcTxSigner for IcBtcSigner {
         &self,
         message: Message,
         derivation_path: &DerivationPath,
-    ) -> Result<Signature, Error> {
+    ) -> Result<Signature, Secp256Error> {
         let request = SignWithEcdsaArgument {
             message_hash: message.as_ref().to_vec(),
             derivation_path: derivation_path_to_ic(derivation_path.clone()),
@@ -73,8 +92,8 @@ impl BtcTxSigner for IcBtcSigner {
         &self,
         _message: Message,
         _derivation_path: &DerivationPath,
-    ) -> Result<bitcoin::secp256k1::schnorr::Signature, Error> {
-        Err(Error::IncorrectSignature)
+    ) -> Result<bitcoin::secp256k1::schnorr::Signature, Secp256Error> {
+        Err(Secp256Error::IncorrectSignature)
     }
 }
 
@@ -84,12 +103,15 @@ pub enum BtcSignerType {
 }
 
 impl BtcSignerType {
-    pub async fn get_transit_address(&self, eth_address: &H160, network: Network) -> Address {
-        let derivation_path = get_derivation_path(eth_address);
+    pub async fn get_transit_address(
+        &self,
+        eth_address: &H160,
+        network: Network,
+    ) -> KeyResult<Address> {
+        let derivation_path = get_derivation_path(eth_address)?;
         let public_key = self.ecdsa_public_key(&derivation_path).await;
 
-        Address::p2wpkh(&public_key, network)
-            .expect("used uncompressed public key to derive address")
+        Address::p2wpkh(&public_key, network).map_err(KeyError::BitcoinAddress)
     }
 }
 
@@ -106,7 +128,7 @@ impl BtcTxSigner for BtcSignerType {
         &self,
         message: Message,
         derivation_path: &DerivationPath,
-    ) -> Result<Signature, Error> {
+    ) -> Result<Signature, Secp256Error> {
         match self {
             BtcSignerType::Local(v) => v.sign_with_ecdsa(message, derivation_path).await,
             BtcSignerType::Ic(v) => v.sign_with_ecdsa(message, derivation_path).await,
@@ -117,7 +139,7 @@ impl BtcTxSigner for BtcSignerType {
         &self,
         message: Message,
         derivation_path: &DerivationPath,
-    ) -> Result<bitcoin::secp256k1::schnorr::Signature, Error> {
+    ) -> Result<bitcoin::secp256k1::schnorr::Signature, Secp256Error> {
         match self {
             BtcSignerType::Local(v) => v.sign_with_schnorr(message, derivation_path).await,
             BtcSignerType::Ic(v) => v.sign_with_schnorr(message, derivation_path).await,
@@ -125,29 +147,24 @@ impl BtcTxSigner for BtcSignerType {
     }
 }
 
-pub fn get_transit_address(
-    state: &RefCell<RuneState>,
-    eth_address: &H160,
-) -> Result<Address, GetAddressError> {
+pub fn get_transit_address(state: &RefCell<RuneState>, eth_address: &H160) -> KeyResult<Address> {
     let state = state.borrow();
-    let public_key = state.public_key();
-    let chain_code = state.chain_code();
+    let public_key = state.public_key().ok_or(KeyError::SignerNotInitialized)?;
+    let chain_code = state.chain_code().ok_or(KeyError::SignerNotInitialized)?;
     let x_public_key = Xpub {
         network: state.network(),
         depth: 0,
         parent_fingerprint: Default::default(),
-        child_number: ChildNumber::from_normal_idx(0).map_err(|_| GetAddressError::Derivation)?,
+        child_number: ChildNumber::from_normal_idx(0)?,
         public_key: public_key.inner,
         chain_code,
     };
-    let derivation_path = get_derivation_path(eth_address);
+    let derivation_path = get_derivation_path(eth_address)?;
     let public_key = x_public_key
-        .derive_pub(&Secp256k1::new(), &derivation_path)
-        .map_err(|_| GetAddressError::Derivation)?
+        .derive_pub(&Secp256k1::new(), &derivation_path)?
         .public_key;
 
-    Ok(Address::p2wpkh(&public_key.into(), state.network())
-        .expect("used uncompressed public key to derive address"))
+    Ok(Address::p2wpkh(&public_key.into(), state.network())?)
 }
 
 pub fn get_derivation_path_ic(eth_address: &H160) -> Vec<Vec<u8>> {
@@ -164,19 +181,23 @@ pub fn get_derivation_path_ic(eth_address: &H160) -> Vec<Vec<u8>> {
     dp
 }
 
-pub fn get_derivation_path(eth_address: &H160) -> DerivationPath {
+pub fn get_derivation_path(eth_address: &H160) -> KeyResult<DerivationPath> {
     ic_dp_to_derivation_path(&get_derivation_path_ic(eth_address))
 }
 
-pub fn ic_dp_to_derivation_path(ic_derivation_path: &[Vec<u8>]) -> DerivationPath {
+pub fn ic_dp_to_derivation_path(ic_derivation_path: &[Vec<u8>]) -> KeyResult<DerivationPath> {
     let mut parts = vec![];
     for part in ic_derivation_path.iter() {
-        let child_idx = u32::from_be_bytes(part[..].try_into().unwrap());
-        let child = ChildNumber::from_normal_idx(child_idx).unwrap();
+        let child_idx = u32::from_be_bytes(
+            part[..]
+                .try_into()
+                .map_err(|_| KeyError::InvalidDerivationPath)?,
+        );
+        let child = ChildNumber::from_normal_idx(child_idx)?;
         parts.push(child);
     }
 
-    DerivationPath::from(parts)
+    Ok(DerivationPath::from(parts))
 }
 
 fn derivation_path_to_ic(derivation_path: DerivationPath) -> Vec<Vec<u8>> {

--- a/src/rune-bridge/src/memory.rs
+++ b/src/rune-bridge/src/memory.rs
@@ -1,19 +1,7 @@
-use ic_stable_structures::stable_structures::DefaultMemoryImpl;
-use ic_stable_structures::{IcMemoryManager, MemoryId};
+use ic_stable_structures::MemoryId;
 
 pub const CONFIG_MEMORY_ID: MemoryId = MemoryId::new(10);
-pub const PENDING_TASKS_MEMORY_ID: MemoryId = MemoryId::new(11);
-pub const SIGNER_MEMORY_ID: MemoryId = MemoryId::new(12);
-pub const LOGGER_SETTINGS_MEMORY_ID: MemoryId = MemoryId::new(13);
-pub const BURN_REQUEST_MEMORY_ID: MemoryId = MemoryId::new(14);
-pub const LEDGER_MEMORY_ID: MemoryId = MemoryId::new(15);
-pub const USED_UTXOS_REGISTRY_MEMORY_ID: MemoryId = MemoryId::new(16);
-pub const RUNE_INFO_BY_UTXO_MEMORY_ID: MemoryId = MemoryId::new(17);
-pub const OPERATIONS_MEMORY_ID: MemoryId = MemoryId::new(18);
-pub const OPERATIONS_LOG_MEMORY_ID: MemoryId = MemoryId::new(19);
-pub const OPERATIONS_MAP_MEMORY_ID: MemoryId = MemoryId::new(20);
-pub const OPERATIONS_COUNTER_MEMORY_ID: MemoryId = MemoryId::new(21);
-
-thread_local! {
-    pub static MEMORY_MANAGER: IcMemoryManager<DefaultMemoryImpl> = IcMemoryManager::init(DefaultMemoryImpl::default());
-}
+pub const DEPOSITED_UTXOS_MEMORY_ID: MemoryId = MemoryId::new(11);
+pub const USED_UTXOS_MEMORY_ID: MemoryId = MemoryId::new(12);
+pub const RUNE_INFO_BY_UTXO_MEMORY_ID: MemoryId = MemoryId::new(13);
+pub const MASTER_KEY_MEMORY_ID: MemoryId = MemoryId::new(14);

--- a/src/rune-bridge/src/rune_info.rs
+++ b/src/rune-bridge/src/rune_info.rs
@@ -95,7 +95,7 @@ impl RuneInfo {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RuneName(Rune);
+pub struct RuneName(pub Rune);
 
 impl RuneName {
     pub fn inner(&self) -> Rune {

--- a/src/rune-bridge/src/state.rs
+++ b/src/rune-bridge/src/state.rs
@@ -1,22 +1,29 @@
+mod config;
+mod master_key;
+
 use core::panic;
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
 use bitcoin::bip32::ChainCode;
 use bitcoin::{FeeRate, Network, PrivateKey, PublicKey};
-use bridge_did::init::BridgeInitData;
-use candid::{CandidType, Deserialize, Principal};
+use bridge_canister::memory::MEMORY_MANAGER;
 use eth_signer::sign_strategy::SigningStrategy;
 use ic_exports::ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_exports::ic_cdk::api::management_canister::ecdsa::{
     EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyResponse,
 };
 use ic_exports::ic_kit::ic;
-use ic_log::did::LogCanisterSettings;
+use ic_stable_structures::stable_structures::DefaultMemoryImpl;
+use ic_stable_structures::VirtualMemory;
 use ord_rs::wallet::LocalSigner;
 use ord_rs::Wallet;
 use ordinals::RuneId;
 
+pub use self::config::RuneBridgeConfig;
+use self::config::RuneBridgeConfigStorage;
+pub use self::master_key::MasterKey;
+use self::master_key::MasterKeyStorage;
 use crate::key::{BtcSignerType, IcBtcSigner};
 use crate::ledger::UtxoLedger;
 use crate::rune_info::{RuneInfo, RuneName};
@@ -24,24 +31,29 @@ use crate::{MAINNET_CHAIN_ID, REGTEST_CHAIN_ID, TESTNET_CHAIN_ID};
 
 const DEFAULT_DEPOSIT_FEE: u64 = 100_000;
 const DEFAULT_MEMPOOL_TIMEOUT: Duration = Duration::from_secs(24 * 60 * 60);
+const DEFAULT_INDEXER_CONSENSUS_THRESHOLD: u8 = 2;
 
 /// Minimum number of indexers required to start the bridge.
-const MIN_INDEXERS: u8 = 2;
+const MIN_INDEXERS: usize = 2;
 
-#[derive(Default)]
 pub struct RuneState {
-    pub(crate) config: RuneBridgeConfig,
-    pub(crate) master_key: Option<MasterKey>,
-    pub(crate) ledger: UtxoLedger,
+    pub(crate) config: RuneBridgeConfigStorage<VirtualMemory<DefaultMemoryImpl>>,
+    pub(crate) master_key: MasterKeyStorage<VirtualMemory<DefaultMemoryImpl>>,
+    pub(crate) ledger: UtxoLedger<VirtualMemory<DefaultMemoryImpl>>,
     pub(crate) runes: HashMap<RuneName, RuneInfo>,
     pub(crate) fee_rate_state: FeeRateState,
 }
 
-#[derive(Debug, Clone)]
-pub struct MasterKey {
-    pub public_key: PublicKey,
-    pub chain_code: ChainCode,
-    pub key_id: EcdsaKeyId,
+impl Default for RuneState {
+    fn default() -> Self {
+        MEMORY_MANAGER.with(|memory_manager| Self {
+            config: RuneBridgeConfigStorage::new(memory_manager),
+            fee_rate_state: FeeRateState::default(),
+            ledger: UtxoLedger::new(memory_manager),
+            master_key: MasterKeyStorage::new(memory_manager),
+            runes: HashMap::default(),
+        })
+    }
 }
 
 pub struct FeeRateState {
@@ -59,90 +71,10 @@ impl Default for FeeRateState {
     }
 }
 
-#[derive(Debug, CandidType, Deserialize, Clone)]
-pub struct RuneBridgeConfig {
-    pub network: BitcoinNetwork,
-    pub evm_principal: Principal,
-    pub signing_strategy: SigningStrategy,
-    pub admin: Principal,
-    pub log_settings: LogCanisterSettings,
-    pub min_confirmations: u32,
-    pub no_of_indexers: u8,
-    pub indexer_urls: HashSet<String>,
-    /// Minimum quantity of indexer nodes required to reach agreement on a
-    /// request
-    pub indexer_consensus_threshold: u8,
-    pub deposit_fee: u64,
-    pub mempool_timeout: Duration,
-}
-
-impl Default for RuneBridgeConfig {
-    fn default() -> Self {
-        Self {
-            network: BitcoinNetwork::Regtest,
-            evm_principal: Principal::management_canister(),
-            signing_strategy: SigningStrategy::Local {
-                private_key: [0; 32],
-            },
-            admin: Principal::management_canister(),
-            log_settings: LogCanisterSettings::default(),
-            min_confirmations: 12,
-            no_of_indexers: MIN_INDEXERS,
-            indexer_consensus_threshold: 2,
-            indexer_urls: HashSet::default(),
-            deposit_fee: DEFAULT_DEPOSIT_FEE,
-            mempool_timeout: DEFAULT_MEMPOOL_TIMEOUT,
-        }
-    }
-}
-
-impl RuneBridgeConfig {
-    pub fn validate(&self) -> Result<(), String> {
-        if self.indexer_urls.is_empty() {
-            return Err("Indexer url is empty".to_string());
-        }
-
-        if self.indexer_urls.len() != self.no_of_indexers as usize {
-            return Err(format!(
-                "Number of indexers ({}) required does not match number of indexer urls ({})",
-                self.no_of_indexers,
-                self.indexer_urls.len()
-            ));
-        }
-
-        if self
-            .indexer_urls
-            .iter()
-            .any(|url| !url.starts_with("https"))
-        {
-            return Err("Indexer url must specify https url".to_string());
-        }
-
-        if self.indexer_consensus_threshold > self.indexer_urls.len() as u8 {
-            return Err(format!(
-               "The consensus threshold ({}) must be less than or equal to the number of indexers ({})",
-                self.indexer_consensus_threshold,
-                self.indexer_urls.len()
-            ));
-        }
-
-        Ok(())
-    }
-
-    pub fn bridge_init_data(&self) -> BridgeInitData {
-        BridgeInitData {
-            owner: self.admin,
-            evm_principal: self.evm_principal,
-            signing_strategy: self.signing_strategy.clone(),
-            log_settings: Some(self.log_settings.clone()),
-        }
-    }
-}
-
 impl RuneState {
     /// Returns id of the IC ECDSA key used by the canister.
-    pub fn ecdsa_key_id(&self) -> EcdsaKeyId {
-        let key_name = match &self.config.signing_strategy {
+    pub fn ecdsa_key_id(&self, signing_strategy: &SigningStrategy) -> EcdsaKeyId {
+        let key_name = match signing_strategy {
             SigningStrategy::Local { .. } => "none".to_string(),
             SigningStrategy::ManagementCanister { key_id } => key_id.to_string(),
         };
@@ -169,29 +101,23 @@ impl RuneState {
     }
 
     /// Returns master public key of the canister.
-    pub fn public_key(&self) -> PublicKey {
-        self.master_key
-            .as_ref()
-            .expect("master key is not initialized")
-            .public_key
+    pub fn public_key(&self) -> Option<PublicKey> {
+        self.master_key.get().as_ref().map(|key| key.public_key)
     }
 
     /// Returns master chain code of the canister. Used for public key derivation.
-    pub fn chain_code(&self) -> ChainCode {
-        self.master_key
-            .as_ref()
-            .expect("master key is not initialized")
-            .chain_code
+    pub fn chain_code(&self) -> Option<ChainCode> {
+        self.master_key.get().as_ref().map(|key| key.chain_code)
     }
 
     /// Returns BTC network the canister works with (IC style).
     pub fn ic_btc_network(&self) -> BitcoinNetwork {
-        self.config.network
+        self.config.get().network
     }
 
     /// Returns BTC network the canister works with (BTC style).
     pub fn network(&self) -> Network {
-        match self.config.network {
+        match self.config.get().network {
             BitcoinNetwork::Mainnet => Network::Bitcoin,
             BitcoinNetwork::Testnet => Network::Testnet,
             BitcoinNetwork::Regtest => Network::Regtest,
@@ -200,52 +126,53 @@ impl RuneState {
 
     /// Minimum number of confirmations the canister requires to consider a transaction to be confirmed.
     pub fn min_confirmations(&self) -> u32 {
-        self.config.min_confirmations
+        self.config.get().min_confirmations
     }
 
-    fn master_key(&self) -> MasterKey {
-        self.master_key.clone().expect("ecdsa is not initialized")
+    /// Master key of the canister.
+    fn master_key(&self) -> Option<MasterKey> {
+        self.master_key.get().clone()
     }
 
-    pub fn btc_signer(&self) -> BtcSignerType {
-        match &self.config.signing_strategy {
+    pub fn btc_signer(&self, signing_strategy: &SigningStrategy) -> Option<BtcSignerType> {
+        Some(match signing_strategy {
             SigningStrategy::Local { private_key } => BtcSignerType::Local(LocalSigner::new(
                 PrivateKey::from_slice(private_key, self.network()).expect("invalid private key"),
             )),
             SigningStrategy::ManagementCanister { .. } => {
-                BtcSignerType::Ic(IcBtcSigner::new(self.master_key(), self.network()))
+                BtcSignerType::Ic(IcBtcSigner::new(self.master_key()?, self.network()))
             }
-        }
+        })
     }
 
     /// Wallet to be used to sign transactions with the given derivation path.
-    pub fn wallet(&self) -> Wallet {
-        Wallet::new_with_signer(self.btc_signer())
+    pub fn wallet(&self, signing_strategy: &SigningStrategy) -> Option<Wallet> {
+        Some(Wallet::new_with_signer(self.btc_signer(signing_strategy)?))
     }
 
     /// BTC fee in SATs for a deposit request.
     pub fn deposit_fee(&self) -> u64 {
-        self.config.deposit_fee
+        self.config.get().deposit_fee
     }
 
     /// Url of the `ord` indexer this canister rely on.
     pub fn indexer_urls(&self) -> HashSet<String> {
-        self.config.indexer_urls.clone()
+        self.config.get().indexer_urls.clone()
     }
 
     /// Utxo ledger.
-    pub fn ledger(&self) -> &UtxoLedger {
+    pub fn ledger(&self) -> &UtxoLedger<VirtualMemory<DefaultMemoryImpl>> {
         &self.ledger
     }
 
     /// Mutable reference to the utxo ledger.
-    pub fn ledger_mut(&mut self) -> &mut UtxoLedger {
+    pub fn ledger_mut(&mut self) -> &mut UtxoLedger<VirtualMemory<DefaultMemoryImpl>> {
         &mut self.ledger
     }
 
     /// Chain id to be used for the rune.
     pub fn btc_chain_id(&self) -> u32 {
-        match self.config.network {
+        match self.config.get().network {
             BitcoinNetwork::Mainnet => MAINNET_CHAIN_ID,
             BitcoinNetwork::Testnet => TESTNET_CHAIN_ID,
             BitcoinNetwork::Regtest => REGTEST_CHAIN_ID,
@@ -265,55 +192,51 @@ impl RuneState {
             .map(|url| url.strip_suffix('/').unwrap_or(url).to_owned())
             .collect();
 
-        self.config = config;
+        self.config.set(config);
     }
 
     /// Updates the ecdsa signing configuration with the given master key information.
     ///
     /// This configuration is used to derive public keys for different user addresses, so this
     /// configuration must be set before any of the transactions can be processed.
-    pub fn configure_ecdsa(&mut self, master_key: EcdsaPublicKeyResponse) {
-        let chain_code: &[u8] = &master_key.chain_code;
-        self.master_key = Some(MasterKey {
+    pub fn configure_ecdsa(
+        &mut self,
+        master_key: EcdsaPublicKeyResponse,
+        key_id: EcdsaKeyId,
+    ) -> Result<(), String> {
+        if master_key.chain_code.len() != 32 {
+            return Err("invalid chain code length".to_string());
+        }
+        let chain_code: [u8; 32] = master_key
+            .chain_code
+            .try_into()
+            .map_err(|e| format!("invalid chain code: {e:?}"))?;
+
+        self.master_key.set(MasterKey {
             public_key: PublicKey::from_slice(&master_key.public_key)
-                .expect("invalid public key slice"),
-            chain_code: ChainCode::try_from(chain_code).expect("invalid chain code slice"),
-            key_id: self.ecdsa_key_id(),
+                .map_err(|e| format!("invalid public key slice: {e}"))?,
+            chain_code: ChainCode::from(chain_code),
+            key_id,
         });
+
+        Ok(())
     }
 
-    pub fn configure_indexers(&mut self, no_of_indexers: u8, indexer_urls: HashSet<String>) {
-        if no_of_indexers < MIN_INDEXERS {
+    pub fn configure_indexers(&mut self, indexer_urls: HashSet<String>) {
+        if indexer_urls.len() < MIN_INDEXERS {
             panic!("number of indexers must be at least {}", MIN_INDEXERS)
         }
 
-        if no_of_indexers < indexer_urls.len() as u8 {
-            panic!(
-                "number of indexers must be at least {}",
-                indexer_urls.len() as u8,
-            );
-        }
-
-        self.config.indexer_urls = indexer_urls
-            .iter()
-            .map(|url| url.strip_suffix('/').unwrap_or(url).to_owned())
-            .collect();
-
-        self.config.no_of_indexers = no_of_indexers;
-    }
-
-    /// Returns the number of indexers required to reach consensus.
-    pub fn indexer_consensus_threshold(&self) -> u8 {
-        self.config.indexer_consensus_threshold
-    }
-
-    /// Sets the number of indexers required to reach consensus.
-    pub fn set_indexer_consensus_threshold(&mut self, threshold: u8) {
-        self.config.indexer_consensus_threshold = threshold;
+        self.config.with_borrow_mut(|config| {
+            config.indexer_urls = indexer_urls
+                .iter()
+                .map(|url| url.strip_suffix('/').unwrap_or(url).to_owned())
+                .collect();
+        });
     }
 
     pub fn mempool_timeout(&self) -> Duration {
-        self.config.mempool_timeout
+        self.config.get().mempool_timeout
     }
 
     /// Update fee rate and the last update timestamp.
@@ -334,6 +257,17 @@ impl RuneState {
             .map(Duration::from_nanos)
             .unwrap_or_default()
     }
+
+    /// Returns the number of indexers required to reach consensus.
+    pub fn indexer_consensus_threshold(&self) -> u8 {
+        self.config.get().indexer_consensus_threshold
+    }
+
+    /// Sets the number of indexers required to reach consensus.
+    pub fn set_indexer_consensus_threshold(&mut self, threshold: u8) {
+        self.config
+            .with_borrow_mut(|config| config.indexer_consensus_threshold = threshold);
+    }
 }
 
 #[cfg(test)]
@@ -346,17 +280,6 @@ mod tests {
     fn test_validate_empty_indexer_urls() {
         let config = RuneBridgeConfig {
             indexer_urls: HashSet::new(),
-            no_of_indexers: 1,
-            ..Default::default()
-        };
-        assert!(config.validate().is_err());
-    }
-
-    #[test]
-    fn test_validate_mismatched_number_of_indexers() {
-        let config = RuneBridgeConfig {
-            indexer_urls: HashSet::from_iter(vec!["https://url.com".to_string()]),
-            no_of_indexers: 2,
             ..Default::default()
         };
         assert!(config.validate().is_err());
@@ -366,7 +289,6 @@ mod tests {
     fn test_validate_non_https_url() {
         let config = RuneBridgeConfig {
             indexer_urls: HashSet::from_iter(vec!["http://url.com".to_string()]),
-            no_of_indexers: 1,
             ..Default::default()
         };
         assert!(config.validate().is_err());
@@ -376,7 +298,6 @@ mod tests {
     fn test_validate_success() {
         let config = RuneBridgeConfig {
             indexer_urls: HashSet::from_iter(vec!["https://url.com".to_string()]),
-            no_of_indexers: 1,
             indexer_consensus_threshold: 1,
             ..Default::default()
         };
@@ -388,10 +309,6 @@ mod tests {
         MockContext::new().inject();
         let config = RuneBridgeConfig {
             indexer_urls: HashSet::from_iter(vec!["https://url.com/".to_string()]),
-            no_of_indexers: 1,
-            signing_strategy: SigningStrategy::Local {
-                private_key: [1; 32],
-            },
             indexer_consensus_threshold: 1,
             ..Default::default()
         };
@@ -414,10 +331,9 @@ mod tests {
         ];
         let indexer_urls: HashSet<String> = urls.into_iter().map(String::from).collect();
 
-        state.configure_indexers(3, indexer_urls.clone());
+        state.configure_indexers(indexer_urls.clone());
 
-        assert_eq!(state.config.no_of_indexers, 3);
-        assert_eq!(state.config.indexer_urls, indexer_urls);
+        assert_eq!(state.config.get().indexer_urls, indexer_urls);
     }
 
     #[test]
@@ -430,10 +346,10 @@ mod tests {
         ];
         let indexer_urls: HashSet<String> = urls.into_iter().map(String::from).collect();
 
-        state.configure_indexers(3, indexer_urls);
+        state.configure_indexers(indexer_urls);
 
         assert_eq!(
-            state.config.indexer_urls,
+            state.config.get().indexer_urls,
             HashSet::from([
                 "http://indexer1.com".to_string(),
                 "http://indexer2.com".to_string(),
@@ -448,21 +364,17 @@ mod tests {
         let mut state = RuneState::default();
         let indexer_urls: HashSet<String> = HashSet::new();
 
-        state.configure_indexers(MIN_INDEXERS - 1, indexer_urls);
+        state.configure_indexers(indexer_urls);
     }
 
     #[test]
     #[should_panic(expected = "number of indexers must be at least")]
     fn test_configure_indexers_fewer_than_urls() {
         let mut state = RuneState::default();
-        let urls = vec![
-            "http://indexer1.com",
-            "http://indexer2.com",
-            "http://indexer3.com",
-        ];
+        let urls = vec!["http://indexer1.com"];
         let indexer_urls: HashSet<String> = urls.into_iter().map(String::from).collect();
 
-        state.configure_indexers(2, indexer_urls);
+        state.configure_indexers(indexer_urls);
     }
 
     #[test]
@@ -471,10 +383,9 @@ mod tests {
         let urls = vec!["http://indexer1.com", "http://indexer2.com"];
         let indexer_urls: HashSet<String> = urls.into_iter().map(String::from).collect();
 
-        state.configure_indexers(3, indexer_urls.clone());
+        state.configure_indexers(indexer_urls.clone());
 
-        assert_eq!(state.config.no_of_indexers, 3);
-        assert_eq!(state.config.indexer_urls, indexer_urls);
+        assert_eq!(state.config.get().indexer_urls, indexer_urls);
     }
 
     #[test]

--- a/src/rune-bridge/src/state/config.rs
+++ b/src/rune-bridge/src/state/config.rs
@@ -1,0 +1,223 @@
+use std::collections::HashSet;
+use std::time::Duration;
+
+use candid::CandidType;
+use ic_exports::ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
+use ic_stable_structures::stable_structures::Memory;
+use ic_stable_structures::{CellStructure, MemoryId, MemoryManager, StableCell, Storable};
+use serde::Deserialize;
+
+use super::{DEFAULT_DEPOSIT_FEE, DEFAULT_INDEXER_CONSENSUS_THRESHOLD, DEFAULT_MEMPOOL_TIMEOUT};
+use crate::memory::CONFIG_MEMORY_ID;
+
+pub struct RuneBridgeConfigStorage<M: Memory> {
+    config: StableCell<RuneBridgeConfig, M>,
+}
+
+impl<M> RuneBridgeConfigStorage<M>
+where
+    M: Memory,
+{
+    pub fn new(memory: &dyn MemoryManager<M, MemoryId>) -> Self {
+        Self {
+            config: StableCell::new(memory.get(CONFIG_MEMORY_ID), RuneBridgeConfig::default())
+                .expect("stable memory config initialization failed"),
+        }
+    }
+
+    pub fn get(&self) -> &RuneBridgeConfig {
+        self.config.get()
+    }
+
+    pub fn set(&mut self, config: RuneBridgeConfig) {
+        self.config.set(config).expect("failed to set config");
+    }
+
+    pub fn with_borrow_mut<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut RuneBridgeConfig),
+    {
+        let mut config = self.config.get().clone();
+
+        f(&mut config);
+
+        self.set(config);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
+pub struct RuneBridgeConfig {
+    pub network: BitcoinNetwork,
+    pub min_confirmations: u32,
+    pub indexer_urls: HashSet<String>,
+    pub deposit_fee: u64,
+    pub mempool_timeout: Duration,
+    /// Minimum quantity of indexer nodes required to reach agreement on a
+    /// request
+    pub indexer_consensus_threshold: u8,
+}
+
+impl Storable for RuneBridgeConfig {
+    const BOUND: ic_stable_structures::Bound = ic_stable_structures::Bound::Unbounded;
+
+    /* Encoding
+       1                                            // network
+       4                                            // min_confirmations
+       1                                            // number of indexers
+       number of indexers * [1 + indexer_url.len]   // [len] + [indexer_url]
+       8                                            // deposit_fee
+       8                                            // mempool_timeout
+       1                                            // indexer_consensus_threshold
+    */
+
+    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+        let mut buf = Vec::with_capacity(
+            1 + 4
+                + 1
+                + self
+                    .indexer_urls
+                    .iter()
+                    .map(|url| 1 + url.len())
+                    .sum::<usize>()
+                + 8
+                + 8
+                + 1,
+        );
+
+        let network_byte = match self.network {
+            BitcoinNetwork::Mainnet => 0,
+            BitcoinNetwork::Testnet => 1,
+            BitcoinNetwork::Regtest => 2,
+        };
+
+        buf.push(network_byte);
+        buf.extend_from_slice(&self.min_confirmations.to_le_bytes());
+        buf.push(self.indexer_urls.len() as u8);
+        for url in &self.indexer_urls {
+            buf.push(url.len() as u8);
+            buf.extend_from_slice(url.as_bytes());
+        }
+        buf.extend_from_slice(&self.deposit_fee.to_le_bytes());
+        buf.extend_from_slice(&(self.mempool_timeout.as_nanos() as u64).to_le_bytes());
+        buf.push(self.indexer_consensus_threshold);
+
+        buf.into()
+    }
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        let mut offset = 0;
+        let network = bytes[offset];
+        offset += 1;
+        let min_confirmations = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
+        offset += 4;
+        let no_of_indexers = bytes[offset];
+        offset += 1;
+        let mut indexer_urls = HashSet::with_capacity(no_of_indexers as usize);
+        for _ in 0..no_of_indexers {
+            let len = bytes[offset] as usize;
+            offset += 1;
+            let url =
+                String::from_utf8(bytes[offset..offset + len].to_vec()).expect("invalid utf8");
+            offset += len;
+            indexer_urls.insert(url);
+        }
+        let deposit_fee = u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap());
+        offset += 8;
+        let mempool_timeout = Duration::from_nanos(u64::from_le_bytes(
+            bytes[offset..offset + 8].try_into().unwrap(),
+        ));
+        offset += 8;
+        let indexer_consensus_threshold = bytes[offset];
+
+        Self {
+            network: match network {
+                0 => BitcoinNetwork::Mainnet,
+                1 => BitcoinNetwork::Testnet,
+                2 => BitcoinNetwork::Regtest,
+                _ => panic!("invalid network"),
+            },
+            min_confirmations,
+            indexer_urls,
+            deposit_fee,
+            mempool_timeout,
+            indexer_consensus_threshold,
+        }
+    }
+}
+
+impl Default for RuneBridgeConfig {
+    fn default() -> Self {
+        Self {
+            network: BitcoinNetwork::Regtest,
+            min_confirmations: 12,
+            indexer_urls: HashSet::default(),
+            deposit_fee: DEFAULT_DEPOSIT_FEE,
+            mempool_timeout: DEFAULT_MEMPOOL_TIMEOUT,
+            indexer_consensus_threshold: DEFAULT_INDEXER_CONSENSUS_THRESHOLD,
+        }
+    }
+}
+
+impl RuneBridgeConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.indexer_urls.is_empty() {
+            return Err("Indexer url is empty".to_string());
+        }
+
+        if self
+            .indexer_urls
+            .iter()
+            .any(|url| !url.starts_with("https"))
+        {
+            return Err("Indexer url must specify https url".to_string());
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_should_encode_and_decode_config() {
+        let config = RuneBridgeConfig {
+            network: BitcoinNetwork::Mainnet,
+            min_confirmations: 12,
+            indexer_urls: vec![
+                "https://indexer1.com".to_string(),
+                "https://indexer2.com".to_string(),
+                "https://indexer3.com".to_string(),
+            ]
+            .into_iter()
+            .collect(),
+            deposit_fee: 100,
+            mempool_timeout: Duration::from_secs(60),
+            indexer_consensus_threshold: 2,
+        };
+
+        let bytes = config.to_bytes();
+        let decoded = RuneBridgeConfig::from_bytes(bytes.clone());
+
+        assert_eq!(config, decoded);
+    }
+
+    #[test]
+    fn test_should_encode_and_decode_config_with_empty_urls() {
+        let config = RuneBridgeConfig {
+            network: BitcoinNetwork::Mainnet,
+            min_confirmations: 12,
+            indexer_urls: HashSet::new(),
+            deposit_fee: 100,
+            mempool_timeout: Duration::from_secs(60),
+            indexer_consensus_threshold: 2,
+        };
+
+        let bytes = config.to_bytes();
+        let decoded = RuneBridgeConfig::from_bytes(bytes.clone());
+
+        assert_eq!(config, decoded);
+    }
+}

--- a/src/rune-bridge/src/state/master_key.rs
+++ b/src/rune-bridge/src/state/master_key.rs
@@ -1,0 +1,118 @@
+use bitcoin::bip32::ChainCode;
+use bitcoin::PublicKey;
+use ic_exports::ic_cdk::api::management_canister::ecdsa::{EcdsaCurve, EcdsaKeyId};
+use ic_stable_structures::stable_structures::Memory;
+use ic_stable_structures::{CellStructure as _, MemoryId, MemoryManager, StableCell, Storable};
+
+use crate::memory::MASTER_KEY_MEMORY_ID;
+
+pub struct MasterKeyStorage<M: Memory> {
+    master_key: StableCell<Option<MasterKey>, M>,
+}
+
+impl<M> MasterKeyStorage<M>
+where
+    M: Memory,
+{
+    /// Creates a new MasterKeyStorage.
+    pub fn new(memory: &dyn MemoryManager<M, MemoryId>) -> Self {
+        Self {
+            master_key: StableCell::new(memory.get(MASTER_KEY_MEMORY_ID), None)
+                .expect("stable memory master key initialization failed"),
+        }
+    }
+
+    /// Returns the master key if it exists.
+    pub fn get(&self) -> &Option<MasterKey> {
+        self.master_key.get()
+    }
+
+    /// Sets the master key.
+    pub fn set(&mut self, master_key: MasterKey) {
+        self.master_key
+            .set(Some(master_key))
+            .expect("failed to set master key");
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MasterKey {
+    pub public_key: PublicKey,
+    pub chain_code: ChainCode,
+    pub key_id: EcdsaKeyId,
+}
+
+impl Storable for MasterKey {
+    const BOUND: ic_stable_structures::Bound = ic_stable_structures::Bound::Bounded {
+        max_size: 65 + 32 + 1 + 1 + 255,
+        is_fixed_size: false,
+    };
+
+    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
+        let mut buf = Vec::with_capacity(Self::BOUND.max_size() as usize);
+        buf.extend_from_slice(&self.public_key.to_bytes());
+        buf.extend_from_slice(&self.chain_code.to_bytes());
+
+        let curve_byte = match self.key_id.curve {
+            EcdsaCurve::Secp256k1 => 0,
+        };
+        buf.push(curve_byte);
+        // push the length of the name
+        buf.push(self.key_id.name.len() as u8);
+        buf.extend_from_slice(self.key_id.name.as_bytes());
+
+        buf.into()
+    }
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        let mut offset = 0;
+        let public_key = PublicKey::from_slice(&bytes[offset..offset + 65]).unwrap();
+        offset += 65;
+        let chain_code: [u8; 32] = bytes[offset..offset + 32].try_into().unwrap();
+        let chain_code = ChainCode::from(chain_code);
+        offset += 32;
+        let curve = match bytes[offset] {
+            0 => EcdsaCurve::Secp256k1,
+            _ => panic!("unsupported curve"),
+        };
+        offset += 1;
+        let name_len = bytes[offset] as usize;
+        offset += 1;
+        let name = String::from_utf8(bytes[offset..offset + name_len].to_vec()).unwrap();
+
+        MasterKey {
+            public_key,
+            chain_code,
+            key_id: EcdsaKeyId { curve, name },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bitcoin::PrivateKey;
+    use ic_stable_structures::default_ic_memory_manager;
+
+    use super::*;
+
+    #[test]
+    fn test_master_key_storage() {
+        let memory_manager = default_ic_memory_manager();
+        let mut storage = MasterKeyStorage::new(&memory_manager);
+
+        let private_key = PrivateKey::generate(bitcoin::Network::Bitcoin);
+        let public_key = private_key.public_key(&bitcoin::secp256k1::Secp256k1::new());
+
+        let master_key = MasterKey {
+            public_key,
+            chain_code: ChainCode::from([2; 32]),
+            key_id: EcdsaKeyId {
+                curve: EcdsaCurve::Secp256k1,
+                name: "key".to_string(),
+            },
+        };
+
+        storage.set(master_key.clone());
+        assert_eq!(storage.get().as_ref().unwrap(), &master_key);
+    }
+}


### PR DESCRIPTION
## Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-988


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
