### PR TITLE
Make `indexer_consensus_threshold` as an arg for rune bridge

### DIFF
--- a/src/bridge-deployer/src/config/rune.rs
+++ b/src/bridge-deployer/src/config/rune.rs
@@ -26,6 +26,9 @@ pub struct RuneBridgeConfig {
     /// to be considered final
     #[arg(long)]
     pub min_confirmations: u32,
+    /// Minimum quantity of indexer nodes required to reach agreement on a
+    /// request
+    pub indexer_consensus_threshold: u8,
     /// The number of indexers to use for the Bitcoin blockchain
     #[arg(long)]
     pub no_of_indexers: u8,
@@ -88,12 +91,11 @@ impl From<RuneBridgeConfig> for rune_bridge::state::RuneBridgeConfig {
                 })
                 .unwrap_or_default(),
             min_confirmations: value.min_confirmations,
-            indexer_consensus_threshold: 3,
             no_of_indexers: value.no_of_indexers,
             indexer_urls: value.indexer_urls.into_iter().collect(),
             deposit_fee: value.deposit_fee,
             mempool_timeout: Duration::from_secs(value.mempool_timeout),
-            indexer_consensus_threshold: value.no_of_indexers,
+            indexer_consensus_threshold: value.indexer_consensus_threshold,
         }
     }
 }


### PR DESCRIPTION
## Issue ticket

Issue ticket link:


## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative
- [x] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [x] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [x] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility


### Testing 

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
