### PR TITLE
Add caching of get_utxos requests

### DIFF
--- a/src/bridge-deployer/src/config/rune.rs
+++ b/src/bridge-deployer/src/config/rune.rs
@@ -11,6 +11,10 @@ pub struct RuneBridgeConfig {
     /// The network to use for the Bitcoin blockchain
     #[arg(long)]
     pub bitcoin_network: BitcoinNetwork,
+    /// Specifies the period for which the result of BTC network requests would persist in the
+    /// canister cache. If set to None or 0, the cache will not be used.
+    #[arg(long)]
+    pub btc_cache_timeout_secs: Option<u32>,
     /// The minimum number of confirmations required for a Bitcoin transaction
     /// to be considered final
     #[arg(long)]
@@ -55,6 +59,7 @@ impl From<RuneBridgeConfig> for bridge_did::init::RuneBridgeConfig {
     fn from(value: RuneBridgeConfig) -> Self {
         Self {
             network: value.bitcoin_network.into(),
+            btc_cache_timeout_secs: value.btc_cache_timeout_secs,
             min_confirmations: value.min_confirmations,
             indexer_urls: value.indexer_urls.into_iter().collect(),
             deposit_fee: value.deposit_fee,

--- a/src/bridge-did/src/init/rune.rs
+++ b/src/bridge-did/src/init/rune.rs
@@ -12,6 +12,10 @@ use super::{DEFAULT_DEPOSIT_FEE, DEFAULT_INDEXER_CONSENSUS_THRESHOLD, DEFAULT_ME
 #[derive(Debug, Clone, PartialEq, Eq, CandidType, Deserialize)]
 pub struct RuneBridgeConfig {
     pub network: BitcoinNetwork,
+
+    /// Specifies the period for which the result of BTC network requests would persist in the
+    /// canister cache. If set to None or 0, the cache will not be used.
+    pub btc_cache_timeout_secs: Option<u32>,
     pub min_confirmations: u32,
     pub indexer_urls: HashSet<String>,
     pub deposit_fee: u64,
@@ -38,6 +42,7 @@ impl Default for RuneBridgeConfig {
     fn default() -> Self {
         Self {
             network: BitcoinNetwork::Regtest,
+            btc_cache_timeout_secs: None,
             min_confirmations: 12,
             indexer_urls: HashSet::default(),
             deposit_fee: DEFAULT_DEPOSIT_FEE,
@@ -74,6 +79,7 @@ mod test {
     fn test_should_encode_and_decode_config() {
         let config = RuneBridgeConfig {
             network: BitcoinNetwork::Mainnet,
+            btc_cache_timeout_secs: Some(300),
             min_confirmations: 12,
             indexer_urls: vec![
                 "https://indexer1.com".to_string(),
@@ -97,6 +103,7 @@ mod test {
     fn test_should_encode_and_decode_config_with_empty_urls() {
         let config = RuneBridgeConfig {
             network: BitcoinNetwork::Mainnet,
+            btc_cache_timeout_secs: None,
             min_confirmations: 12,
             indexer_urls: HashSet::new(),
             deposit_fee: 100,

--- a/src/bridge-did/src/init/rune.rs
+++ b/src/bridge-did/src/init/rune.rs
@@ -1,7 +1,8 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::time::Duration;
 
-use candid::CandidType;
+use candid::{CandidType, Decode, Encode};
 use ic_exports::ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_stable_structures::Storable;
 use serde::Deserialize;
@@ -21,91 +22,16 @@ pub struct RuneBridgeConfig {
 }
 
 impl Storable for RuneBridgeConfig {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let bytes = Encode!(self).expect("failed to encode rune config");
+        Cow::Owned(bytes)
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        Decode!(&bytes, Self).expect("failed to decode rune config")
+    }
+
     const BOUND: ic_stable_structures::Bound = ic_stable_structures::Bound::Unbounded;
-
-    /* Encoding
-       1                                            // network
-       4                                            // min_confirmations
-       1                                            // number of indexers
-       number of indexers * [1 + indexer_url.len]   // [len] + [indexer_url]
-       8                                            // deposit_fee
-       8                                            // mempool_timeout
-       1                                            // indexer_consensus_threshold
-    */
-
-    fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
-        let mut buf = Vec::with_capacity(
-            1 + 4
-                + 1
-                + self
-                    .indexer_urls
-                    .iter()
-                    .map(|url| 1 + url.len())
-                    .sum::<usize>()
-                + 8
-                + 8
-                + 1,
-        );
-
-        let network_byte = match self.network {
-            BitcoinNetwork::Mainnet => 0,
-            BitcoinNetwork::Testnet => 1,
-            BitcoinNetwork::Regtest => 2,
-        };
-
-        buf.push(network_byte);
-        buf.extend_from_slice(&self.min_confirmations.to_le_bytes());
-        buf.push(self.indexer_urls.len() as u8);
-        for url in &self.indexer_urls {
-            buf.push(url.len() as u8);
-            buf.extend_from_slice(url.as_bytes());
-        }
-        buf.extend_from_slice(&self.deposit_fee.to_le_bytes());
-        buf.extend_from_slice(&(self.mempool_timeout.as_nanos() as u64).to_le_bytes());
-        buf.push(self.indexer_consensus_threshold);
-
-        buf.into()
-    }
-
-    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
-        let mut offset = 0;
-        let network = bytes[offset];
-        offset += 1;
-        let min_confirmations = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
-        offset += 4;
-        let no_of_indexers = bytes[offset];
-        offset += 1;
-        let mut indexer_urls = HashSet::with_capacity(no_of_indexers as usize);
-        for _ in 0..no_of_indexers {
-            let len = bytes[offset] as usize;
-            offset += 1;
-            let url =
-                String::from_utf8(bytes[offset..offset + len].to_vec()).expect("invalid utf8");
-            offset += len;
-            indexer_urls.insert(url);
-        }
-        let deposit_fee = u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap());
-        offset += 8;
-        let mempool_timeout = Duration::from_nanos(u64::from_le_bytes(
-            bytes[offset..offset + 8].try_into().unwrap(),
-        ));
-        offset += 8;
-        let indexer_consensus_threshold = bytes[offset];
-
-        Self {
-            network: match network {
-                0 => BitcoinNetwork::Mainnet,
-                1 => BitcoinNetwork::Testnet,
-                2 => BitcoinNetwork::Regtest,
-                _ => panic!("invalid network"),
-            },
-            min_confirmations,
-            indexer_urls,
-            deposit_fee,
-            mempool_timeout,
-            indexer_consensus_threshold,
-        }
-    }
 }
 
 impl Default for RuneBridgeConfig {

--- a/src/integration-tests/tests/dfx_tests/runes.rs
+++ b/src/integration-tests/tests/dfx_tests/runes.rs
@@ -161,6 +161,7 @@ impl RunesContext {
 
         let rune_config = RuneBridgeConfig {
             network: BitcoinNetwork::Regtest,
+            btc_cache_timeout_secs: None,
             min_confirmations: 1,
             indexer_urls: HashSet::from_iter(["https://localhost:8001".to_string()]),
             deposit_fee: 500_000,

--- a/src/integration-tests/tests/state_machine_tests/rune.rs
+++ b/src/integration-tests/tests/state_machine_tests/rune.rs
@@ -49,6 +49,7 @@ impl RunesSetup {
         };
         let rune_config = RuneBridgeConfig {
             network: BitcoinNetwork::Mainnet,
+            btc_cache_timeout_secs: None,
             min_confirmations: 1,
             indexer_urls: HashSet::from_iter(["https://indexer".to_string()]),
             deposit_fee: 0,

--- a/src/rune-bridge/src/core/deposit.rs
+++ b/src/rune-bridge/src/core/deposit.rs
@@ -138,6 +138,7 @@ impl RuneDeposit<IcUtxoProvider, OrdIndexProvider<IcHttpClient>> {
 
         let network = state_ref.network();
         let ic_network = state_ref.ic_btc_network();
+        let cache_timeout = state_ref.utxo_cache_timeout();
         let indexer_urls = state_ref.indexer_urls();
         let signer = state_ref
             .btc_signer(&signer_strategy)
@@ -151,7 +152,7 @@ impl RuneDeposit<IcUtxoProvider, OrdIndexProvider<IcHttpClient>> {
             runtime_state,
             network,
             signer,
-            utxo_provider: IcUtxoProvider::new(ic_network),
+            utxo_provider: IcUtxoProvider::new(ic_network, cache_timeout),
             index_provider: OrdIndexProvider::new(
                 IcHttpClient {},
                 indexer_urls,

--- a/src/rune-bridge/src/core/utxo_provider.rs
+++ b/src/rune-bridge/src/core/utxo_provider.rs
@@ -217,8 +217,7 @@ mod tests {
         let s = Secp256k1::new();
         let public_key = PublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
 
-        let address = Address::p2pkh(&public_key, Network::Bitcoin);
-        address
+        Address::p2pkh(&public_key, Network::Bitcoin)
     }
 
     fn mock_response(v: u32) -> GetUtxosResponse {

--- a/src/rune-bridge/src/core/utxo_provider.rs
+++ b/src/rune-bridge/src/core/utxo_provider.rs
@@ -1,3 +1,9 @@
+use std::cell::RefCell;
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+use std::rc::Rc;
+use std::time::Duration;
+
 use bitcoin::consensus::Encodable;
 use bitcoin::{Address, FeeRate, Transaction};
 use ic_exports::ic_cdk::api::management_canister::bitcoin::{
@@ -5,6 +11,7 @@ use ic_exports::ic_cdk::api::management_canister::bitcoin::{
     BitcoinNetwork, GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse,
     SendTransactionRequest,
 };
+use ic_exports::ic_kit::ic;
 
 use crate::core::rune_inputs::GetInputsError;
 use crate::interface::WithdrawError;
@@ -15,20 +22,49 @@ pub(crate) trait UtxoProvider {
     async fn send_tx(&self, transaction: &Transaction) -> Result<(), WithdrawError>;
 }
 
+type IcTimestamp = u64;
+
+#[derive(Debug, PartialEq, Eq)]
+struct UtxoCacheEntry {
+    ts: IcTimestamp,
+    address: Address,
+    response: GetUtxosResponse,
+}
+
+impl PartialOrd<Self> for UtxoCacheEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for UtxoCacheEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.ts
+            .cmp(&other.ts)
+            .then(self.response.cmp(&other.response))
+    }
+}
+
+thread_local! {
+    static UTXO_CACHE: Rc<RefCell<BTreeSet<UtxoCacheEntry>>> = Default::default();
+}
+
 pub struct IcUtxoProvider {
     network: BitcoinNetwork,
+    utxo_cache_timeout: Duration,
 }
 
 const DEFAULT_REGTEST_FEE: u64 = 100_000 * 1_000;
 
 impl IcUtxoProvider {
-    pub fn new(network: BitcoinNetwork) -> Self {
-        Self { network }
+    pub fn new(network: BitcoinNetwork, utxo_cache_timeout: Duration) -> Self {
+        Self {
+            network,
+            utxo_cache_timeout,
+        }
     }
-}
 
-impl UtxoProvider for IcUtxoProvider {
-    async fn get_utxos(&self, address: &Address) -> Result<GetUtxosResponse, GetInputsError> {
+    async fn request_utxos(&self, address: &Address) -> Result<GetUtxosResponse, GetInputsError> {
         let args = GetUtxosRequest {
             address: address.to_string(),
             network: self.network,
@@ -46,6 +82,61 @@ impl UtxoProvider for IcUtxoProvider {
         log::trace!("{response:?}");
 
         Ok(response)
+    }
+
+    fn get_cached_utxos(&self, address: &Address) -> Option<GetUtxosResponse> {
+        UTXO_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            let invalidate_ts = ic::time() - self.utxo_cache_timeout.as_nanos() as u64;
+            while !cache.is_empty() {
+                if cache.first().expect("no entries").ts < invalidate_ts {
+                    cache.pop_first();
+                    continue;
+                } else {
+                    break;
+                }
+            }
+
+            cache
+                .iter()
+                .find(|v| v.address == *address)
+                .map(|v| v.response.clone())
+        })
+    }
+
+    fn cache_utxo_response(&self, address: Address, response: GetUtxosResponse) {
+        if self.utxo_cache_timeout == Duration::default() {
+            return;
+        }
+
+        UTXO_CACHE.with(move |cache| {
+            let mut cache = cache.borrow_mut();
+            let curr_ts = ic::time();
+            cache.insert(UtxoCacheEntry {
+                ts: curr_ts,
+                address,
+                response,
+            });
+        });
+    }
+}
+
+impl UtxoProvider for IcUtxoProvider {
+    async fn get_utxos(&self, address: &Address) -> Result<GetUtxosResponse, GetInputsError> {
+        match self.get_cached_utxos(address) {
+            Some(v) => {
+                log::trace!("UTXO list for address {address} found in cache");
+                Ok(v)
+            }
+            None => {
+                let response = self.request_utxos(address).await;
+                if let Ok(resp) = &response {
+                    self.cache_utxo_response(address.clone(), resp.clone());
+                }
+
+                response
+            }
+        }
     }
 
     async fn get_fee_rate(&self) -> Result<FeeRate, WithdrawError> {
@@ -111,5 +202,114 @@ impl UtxoProvider for IcUtxoProvider {
         log::trace!("Transaction {} sent to the adapter", transaction.txid());
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::secp256k1::Secp256k1;
+    use bitcoin::{Network, PublicKey};
+    use ic_exports::ic_kit::MockContext;
+
+    use super::*;
+
+    fn address() -> Address {
+        let s = Secp256k1::new();
+        let public_key = PublicKey::new(s.generate_keypair(&mut rand::thread_rng()).1);
+
+        let address = Address::p2pkh(&public_key, Network::Bitcoin);
+        address
+    }
+
+    fn mock_response(v: u32) -> GetUtxosResponse {
+        GetUtxosResponse {
+            utxos: vec![],
+            tip_block_hash: vec![],
+            tip_height: v,
+            next_page: None,
+        }
+    }
+
+    #[test]
+    fn cached_items_with_same_ts() {
+        MockContext::new().inject();
+        let provider = IcUtxoProvider::new(BitcoinNetwork::Mainnet, Duration::from_secs(1));
+        let a1 = address();
+        let r1 = mock_response(1);
+        let a2 = address();
+        let r2 = mock_response(2);
+
+        provider.cache_utxo_response(a1.clone(), r1.clone());
+        provider.cache_utxo_response(a2.clone(), r2.clone());
+
+        assert_eq!(provider.get_cached_utxos(&a1), Some(r1));
+        assert_eq!(provider.get_cached_utxos(&a2), Some(r2));
+    }
+
+    #[test]
+    fn cached_items_are_removed() {
+        let ctx = MockContext::new().inject();
+        let provider = IcUtxoProvider::new(BitcoinNetwork::Mainnet, Duration::from_secs(60));
+        let a1 = address();
+        let r1 = mock_response(1);
+        let a2 = address();
+        let r2 = mock_response(2);
+        let a3 = address();
+        let r3 = mock_response(3);
+
+        provider.cache_utxo_response(a1.clone(), r1.clone());
+        ctx.add_time(Duration::from_secs(1).as_nanos() as u64);
+        provider.cache_utxo_response(a2.clone(), r2.clone());
+        ctx.add_time(Duration::from_secs(30).as_nanos() as u64);
+        provider.cache_utxo_response(a3.clone(), r3.clone());
+        ctx.add_time(Duration::from_secs(30).as_nanos() as u64);
+
+        assert_eq!(provider.get_cached_utxos(&a1), None);
+        assert_eq!(provider.get_cached_utxos(&a2), Some(r2));
+        assert_eq!(provider.get_cached_utxos(&a3), Some(r3));
+    }
+
+    #[tokio::test]
+    async fn get_utxos_returns_cached_value() {
+        let ctx = MockContext::new().inject();
+        let provider = IcUtxoProvider::new(BitcoinNetwork::Mainnet, Duration::from_secs(60));
+        let a1 = address();
+        let r1 = mock_response(1);
+
+        provider.cache_utxo_response(a1.clone(), r1.clone());
+        ctx.add_time(Duration::from_secs(30).as_nanos() as u64);
+
+        assert_eq!(provider.get_utxos(&a1).await, Ok(r1));
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "call_new should only be called inside canisters")]
+    async fn get_utxos_requests_if_not_in_cache() {
+        let ctx = MockContext::new().inject();
+        let provider = IcUtxoProvider::new(BitcoinNetwork::Mainnet, Duration::from_secs(60));
+        let a1 = address();
+        let r1 = mock_response(1);
+        let a2 = address();
+
+        provider.cache_utxo_response(a1.clone(), r1.clone());
+        ctx.add_time(Duration::from_secs(30).as_nanos() as u64);
+
+        assert_eq!(provider.get_utxos(&a2).await, Ok(r1));
+    }
+
+    #[test]
+    fn should_skip_caching_if_disabled() {
+        MockContext::new().inject();
+        let provider = IcUtxoProvider::new(BitcoinNetwork::Mainnet, Duration::from_secs(0));
+        let a1 = address();
+        let r1 = mock_response(1);
+        let a2 = address();
+        let r2 = mock_response(2);
+
+        provider.cache_utxo_response(a1.clone(), r1.clone());
+        provider.cache_utxo_response(a2.clone(), r2.clone());
+
+        assert_eq!(provider.get_cached_utxos(&a1), None);
+        assert_eq!(provider.get_cached_utxos(&a2), None);
     }
 }

--- a/src/rune-bridge/src/core/withdrawal.rs
+++ b/src/rune-bridge/src/core/withdrawal.rs
@@ -98,6 +98,7 @@ impl Withdrawal<IcUtxoProvider> {
 
         let network = state_ref.network();
         let ic_network = state_ref.ic_btc_network();
+        let cache_timeout = state_ref.utxo_cache_timeout();
         let signer = state_ref
             .btc_signer(&signing_strategy)
             .ok_or(WithdrawError::SignerNotInitialized)?;
@@ -108,7 +109,7 @@ impl Withdrawal<IcUtxoProvider> {
             state,
             network,
             signer,
-            utxo_provider: IcUtxoProvider::new(ic_network),
+            utxo_provider: IcUtxoProvider::new(ic_network, cache_timeout),
         })
     }
 

--- a/src/rune-bridge/src/state.rs
+++ b/src/rune-bridge/src/state.rs
@@ -111,6 +111,10 @@ impl RuneState {
         self.config.get().network
     }
 
+    pub fn utxo_cache_timeout(&self) -> Duration {
+        Duration::from_secs(self.config.get().btc_cache_timeout_secs.unwrap_or(0) as u64)
+    }
+
     /// Returns BTC network the canister works with (BTC style).
     pub fn network(&self) -> Network {
         match self.config.get().network {


### PR DESCRIPTION
Adds caching for get_utxos requests in the rune bridge. The cache persests for the period configured in the `RuneBridgeConfig`.

I also changed the way `RuneBridgeConfig` is serialized to simplify adding new fields in the future and make it more reliable.

## Issue ticket

Issue ticket link: https://infinityswap.atlassian.net/browse/EPROD-983


## Checklist before requesting a review

### Code conventions

- [x] I have performed a self-review of my code
- [x] Every new function is documented
- [x] Object names are auto explicative
- [x] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [x] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [x] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [x] The PR does not break APIs backward compatibility
- [x] The PR does not break the stable storage backward compatibility


### Testing 

- [x] Every function is properly unit tested
- [x] I have added integration tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] IC endpoints are always tested through the `canister_call!` macro
