### PR TITLE
EPROD-1031 always deploy bft on install; always reuse on reinstall

### DIFF
--- a/src/bridge-deployer/src/commands/mod.rs
+++ b/src/bridge-deployer/src/commands/mod.rs
@@ -211,7 +211,7 @@ impl Commands {
             }
             Commands::Reinstall(reinstall) => {
                 reinstall
-                    .reinstall_canister(identity, ic_host, network, pk, canister_ids_path)
+                    .reinstall_canister(identity, ic_host, network, canister_ids_path)
                     .await?
             }
             Commands::Upgrade(upgrade) => upgrade.upgrade_canister(identity, ic_host).await?,
@@ -223,16 +223,6 @@ impl Commands {
 
 #[derive(Debug, Args)]
 pub struct BFTArgs {
-    /// Deploy and configure new BFT bridge contract (together with FeeCharge contract)
-    ///
-    /// This argument cannot be used together with `--use-bft`.
-    #[arg(
-        long,
-        conflicts_with = "existing",
-        required_unless_present = "existing"
-    )]
-    deploy_bft: bool,
-
     /// The address of the owner of the contract. Must be used with `--deploy-bft`.
     #[arg(long, value_name = "OWNER", requires = "deploy_bft")]
     owner: Option<H160>,
@@ -240,26 +230,6 @@ pub struct BFTArgs {
     /// The list of controllers for the contract. Must be used with `--deploy-bft`.
     #[arg(long, value_name = "CONTROLLERS", requires = "deploy_bft")]
     controllers: Option<Vec<H160>>,
-
-    /// Configure existing BFT bridge contract to work with the deployed bridge.
-    ///
-    /// This argument cannot be used together with `--deploy-bft`.
-    #[arg(
-        long = "use-bft",
-        required_unless_present = "deploy_bft",
-        value_name = "ADDRESS"
-    )]
-    existing_bft_bridge: Option<H160>,
-
-    /// Configure existing Wrapped token deployer bridge contract to work with the deployed bridge.
-    ///
-    /// This argument cannot be used together with `--deploy-bft`.
-    #[arg(
-        long = "use-token-deployer",
-        required_unless_present = "deploy_bft",
-        value_name = "ADDRESS"
-    )]
-    existing_wrapped_token_deployer: Option<H160>,
 }
 
 pub struct BftDeployedContracts {
@@ -277,16 +247,6 @@ impl BFTArgs {
         pk: H256,
         agent: &Agent,
     ) -> anyhow::Result<BftDeployedContracts> {
-        if let (Some(bft_bridge), Some(wrapped_token_deployer)) = (
-            self.existing_bft_bridge,
-            self.existing_wrapped_token_deployer,
-        ) {
-            return Ok(BftDeployedContracts {
-                bft_bridge,
-                wrapped_token_deployer,
-            });
-        }
-
         info!("Deploying BFT bridge");
 
         let contract_deployer = SolidityContractDeployer::new(network, pk);

--- a/src/bridge-deployer/src/commands/reinstall.rs
+++ b/src/bridge-deployer/src/commands/reinstall.rs
@@ -2,16 +2,15 @@ use std::path::PathBuf;
 
 use candid::Principal;
 use clap::Parser;
-use ethereum_types::H256;
+use ethereum_types::H160;
 use ic_agent::{Agent, Identity};
 use ic_canister_client::agent::identity::GenericIdentity;
 use ic_utils::interfaces::management_canister::builders::InstallMode;
 use tracing::{debug, info};
 
-use super::{BFTArgs, Bridge};
+use super::Bridge;
 use crate::bridge_deployer::BridgeDeployer;
 use crate::canister_ids::{CanisterIds, CanisterIdsPath};
-use crate::commands::BftDeployedContracts;
 use crate::contracts::EvmNetwork;
 
 /// The reinstall command.
@@ -38,9 +37,9 @@ pub struct ReinstallCommands {
     #[arg(long, value_name = "WASM_PATH")]
     wasm: PathBuf,
 
-    /// These are extra arguments for the BFT bridge.
-    #[command(flatten, next_help_heading = "Bridge Contract Args")]
-    bft_args: BFTArgs,
+    /// Existing BFT bridge contract address to work with the deployed bridge.
+    #[arg(long = "bft-bridge", value_name = "ADDRESS")]
+    bft_bridge: H160,
 }
 
 impl ReinstallCommands {
@@ -49,7 +48,6 @@ impl ReinstallCommands {
         identity: PathBuf,
         ic_host: &str,
         network: EvmNetwork,
-        pk: H256,
         canister_ids_path: CanisterIdsPath,
     ) -> anyhow::Result<()> {
         info!("Starting canister reinstall");
@@ -88,21 +86,7 @@ impl ReinstallCommands {
 
         info!("Canister installed successfully");
 
-        let BftDeployedContracts { bft_bridge, .. } = self
-            .bft_args
-            .deploy_bft(
-                network,
-                deployer.bridge_principal(),
-                &self.bridge_type,
-                pk,
-                &agent,
-            )
-            .await?;
-
-        info!("BFT bridge deployed successfully with address: {bft_bridge}");
-        println!("BFT bridge deployed with address: {bft_bridge}");
-
-        deployer.configure_minter(bft_bridge).await?;
+        deployer.configure_minter(self.bft_bridge).await?;
 
         info!("Canister reinstalled successfully with ID: {}", canister_id);
 


### PR DESCRIPTION
## Issue ticket

Issue ticket link:


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
