### PR TITLE
EPROD-1010 remove mint() in bft bridge

### DIFF
--- a/solidity/src/BftBridge.sol
+++ b/solidity/src/BftBridge.sol
@@ -210,24 +210,6 @@ contract BFTBridge is TokenManager, UUPSUpgradeable, OwnableUpgradeable, Pausabl
         controllerAccessList[controller] = false;
     }
 
-    /// Transfer funds to user according the signed encoded order.
-    function mint(
-        bytes calldata encodedOrder
-    ) external whenNotPaused {
-        MintOrderData memory order = _decodeOrder(encodedOrder[:MINT_ORDER_DATA_LEN]);
-        _validateOrder(order);
-        _checkMintOrderSignature(encodedOrder);
-
-        uint256 feeAmount = 0;
-        if (_isFeeRequired()) {
-            feeAmount = (COMMON_BATCH_MINT_GAS_FEE + ORDER_BATCH_MINT_GAS_FEE) * tx.gasprice;
-        }
-
-        _mintInner(order);
-        _chargeFee(order.feePayer, order.senderID, feeAmount);
-        _emitMintedEvent(order, feeAmount);
-    }
-
     /// Transfer funds to users according the signed encoded orders.
     /// Returns `processedOrders` array of error codes for each mint order;
     function batchMint(

--- a/src/bridge-canister/src/bridge.rs
+++ b/src/bridge-canister/src/bridge.rs
@@ -5,12 +5,11 @@ use bridge_did::event_data::*;
 use bridge_did::evm_link::EvmLink;
 use bridge_did::op_id::OperationId;
 use bridge_did::operation_log::Memo;
-use bridge_did::order::SignedMintOrder;
-use bridge_utils::bft_events::{self, BridgeEvent};
+use bridge_utils::bft_events::BridgeEvent;
 use bridge_utils::evm_bridge::EvmParams;
 use bridge_utils::evm_link::EvmLinkClient;
 use candid::CandidType;
-use did::{H160, H256};
+use did::H160;
 use eth_signer::sign_strategy::TransactionSigner;
 use ic_task_scheduler::task::TaskOptions;
 use serde::de::DeserializeOwned;
@@ -73,32 +72,6 @@ pub trait OperationContext {
 
     /// Get signer for transactions, orders, etc...
     fn get_signer(&self) -> BftResult<impl TransactionSigner>;
-
-    /// Send mint transaction with the given `order` to EVM.
-    async fn send_mint_transaction(&self, order: &SignedMintOrder) -> BftResult<H256> {
-        let signer = self.get_signer()?;
-        let sender = signer.get_address().await?;
-        let bridge_contract = self.get_bridge_contract_address()?;
-        let evm_params = self.get_evm_params()?;
-
-        let tx_params = evm_params.create_tx_params(sender, bridge_contract);
-        let mut tx = bft_events::mint_transaction(tx_params, &order.0);
-
-        let signature = signer.sign_transaction(&(&tx).into()).await?;
-        tx.r = signature.r.0;
-        tx.s = signature.s.0;
-        tx.v = signature.v.0;
-        tx.hash = tx.hash();
-
-        let link = self.get_evm_link();
-        let client = link.get_json_rpc_client();
-        let tx_hash = client
-            .send_raw_transaction(tx)
-            .await
-            .map_err(|e| Error::EvmRequestFailed(format!("failed to send mint tx to EVM: {e}")))?;
-
-        Ok(tx_hash.into())
-    }
 
     async fn collect_evm_events(&self, max_logs_number: u64) -> BftResult<CollectedEvents> {
         log::trace!("collecting evm events");

--- a/src/bridge-utils/src/bft_events.rs
+++ b/src/bridge-utils/src/bft_events.rs
@@ -162,28 +162,6 @@ pub struct TxParams {
     pub chain_id: u32,
 }
 
-/// Sends transaction with given params to call `mint` function
-/// in BftBridge contract.
-pub fn mint_transaction(params: TxParams, mint_order_data: &[u8]) -> Transaction {
-    let data = BFTBridge::mintCall {
-        encodedOrder: mint_order_data.to_vec().into(),
-    }
-    .abi_encode();
-
-    pub const DEFAULT_TX_GAS_LIMIT: u64 = 3_000_000;
-    ethers_core::types::Transaction {
-        from: params.sender,
-        to: params.bridge.into(),
-        nonce: params.nonce,
-        value: U256::zero(),
-        gas: DEFAULT_TX_GAS_LIMIT.into(),
-        gas_price: Some(params.gas_price),
-        input: data.into(),
-        chain_id: Some(params.chain_id.into()),
-        ..Default::default()
-    }
-}
-
 /// Sends transaction with given params to call `batchMint` function
 /// in BftBridge contract.
 pub fn batch_mint_transaction(

--- a/src/integration-tests/tests/context/mod.rs
+++ b/src/integration-tests/tests/context/mod.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use bridge_did::error::BftResult as McResult;
 use bridge_did::id256::Id256;
 use bridge_did::operation_log::Memo;
-use bridge_did::order::{SignedMintOrder, SignedOrders};
+use bridge_did::order::SignedOrders;
 use bridge_did::reason::{ApproveAfterMint, Icrc2Burn};
 use bridge_utils::evm_link::address_to_icrc_subaccount;
 use bridge_utils::{BFTBridge, FeeCharge, UUPSProxy, WrappedToken, WrappedTokenDeployer};
@@ -790,23 +790,6 @@ pub trait TestContext {
 
         client.icrc2_approve(approve_args).await?.unwrap();
         Ok(())
-    }
-
-    /// Mints ERC-20 token with the order.
-    async fn mint_erc_20_with_order(
-        &self,
-        wallet: &Wallet<'_, SigningKey>,
-        bridge: &H160,
-        order: SignedMintOrder,
-    ) -> Result<TransactionReceipt> {
-        let input = BFTBridge::mintCall {
-            encodedOrder: order.0.to_vec().into(),
-        }
-        .abi_encode();
-
-        self.call_contract(wallet, bridge, input, 0)
-            .await
-            .map(|(_, receipt)| receipt)
     }
 
     /// Mints ERC-20 token with the order.


### PR DESCRIPTION
## Issue ticket

Issue ticket link:


## Checklist before requesting a review

### Code conventions

- [ ] I have performed a self-review of my code
- [ ] Every new function is documented
- [ ] Object names are auto explicative
- [ ] The PR follows the [project conventions](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/23330839/Conventions)
- [ ] The code follows the [style guidelines of the project](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/24444929/Rust+Conventions)
- [ ] The code follows the [project security best practices](https://infinityswap.atlassian.net/wiki/spaces/CPROD/pages/35225620/Security+Considerations)


### Security 

- [ ] The PR does not break APIs backward compatibility
- [ ] The PR does not break the stable storage backward compatibility


### Testing 

- [ ] Every function is properly unit tested
- [ ] I have added integration tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] IC endpoints are always tested through the `canister_call!` macro
